### PR TITLE
Use SafeHandle for references to unmanaged objects

### DIFF
--- a/src/Microsoft.Data.SQLite/Interop/DatabaseHandle.cs
+++ b/src/Microsoft.Data.SQLite/Interop/DatabaseHandle.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Data.SQLite.Interop
+{
+    internal class DatabaseHandle : SafeHandle
+    {
+        private DatabaseHandle()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            var rc = NativeMethods.sqlite3_close_v2(handle);
+            handle = IntPtr.Zero;
+
+            return rc == Constants.SQLITE_OK;
+        }
+    }
+}

--- a/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.SQLite.Interop
     internal static class NativeMethods
     {
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern int sqlite3_changes(IntPtr db);
+        public static extern int sqlite3_changes(DatabaseHandle db);
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int sqlite3_close_v2(IntPtr db);
@@ -41,9 +41,9 @@ namespace Microsoft.Data.SQLite.Interop
         }
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        private static extern int sqlite3_open_v2(IntPtr filename, out IntPtr ppDb, int flags, IntPtr zVfs);
+        private static extern int sqlite3_open_v2(IntPtr filename, out DatabaseHandle ppDb, int flags, IntPtr zVfs);
 
-        public static int sqlite3_open_v2(string filename, out IntPtr ppDb, int flags, string zVfs)
+        public static int sqlite3_open_v2(string filename, out DatabaseHandle ppDb, int flags, string zVfs)
         {
             var filenamePtr = MarshalEx.StringToHGlobalUTF8(filename);
             var zVfsPtr = MarshalEx.StringToHGlobalUTF8(zVfs);
@@ -62,17 +62,17 @@ namespace Microsoft.Data.SQLite.Interop
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         private static extern int sqlite3_prepare_v2(
-            IntPtr db,
+            DatabaseHandle db,
             IntPtr zSql,
             int nByte,
-            out IntPtr ppStmt,
+            out StatementHandle ppStmt,
             out IntPtr pzTail);
 
         public static int sqlite3_prepare_v2(
-            IntPtr db,
+            DatabaseHandle db,
             string zSql,
             int nByte,
-            out IntPtr ppStmt,
+            out StatementHandle ppStmt,
             out string pzTail)
         {
             var zSqlPtr = MarshalEx.StringToHGlobalUTF8(zSql);
@@ -92,9 +92,9 @@ namespace Microsoft.Data.SQLite.Interop
         }
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern int sqlite3_reset(IntPtr pStmt);
+        public static extern int sqlite3_reset(StatementHandle pStmt);
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern int sqlite3_step(IntPtr pStmt);
+        public static extern int sqlite3_step(StatementHandle pStmt);
     }
 }

--- a/src/Microsoft.Data.SQLite/Interop/StatementHandle.cs
+++ b/src/Microsoft.Data.SQLite/Interop/StatementHandle.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Data.SQLite.Interop
+{
+    internal class StatementHandle : SafeHandle
+    {
+        private StatementHandle()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            var rc = NativeMethods.sqlite3_finalize(handle);
+            handle = IntPtr.Zero;
+
+            return rc == Constants.SQLITE_OK;
+        }
+    }
+}

--- a/test/Microsoft.Data.SQLite.Tests/Microsoft.Data.SQLite.Tests.net45.csproj
+++ b/test/Microsoft.Data.SQLite.Tests/Microsoft.Data.SQLite.Tests.net45.csproj
@@ -44,7 +44,7 @@
     </Reference>
     <Reference Include="System.Data.Common, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Data.Common.0.1-alpha-024\lib\net45\System.Data.Common.dll</HintPath>
+      <HintPath>..\..\packages\System.Data.Common.0.1-alpha-029\lib\net45\System.Data.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.Data.SQLite.Tests/SQLiteCommandTest.cs
+++ b/test/Microsoft.Data.SQLite.Tests/SQLiteCommandTest.cs
@@ -67,12 +67,18 @@ namespace Microsoft.Data.SQLite
         }
 
         [Fact]
-        public void Prepare_throws_when_disposed()
+        public void Prepare_can_be_called_when_disposed()
         {
-            var command = new SQLiteCommand();
-            command.Dispose();
+            using (var connection = new SQLiteConnection("Filename=test.db"))
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT 1";
+                command.Dispose();
+                command.Connection = connection;
+                connection.Open();
 
-            Assert.Throws<ObjectDisposedException>(() => command.Prepare());
+                command.Prepare();
+            }
         }
 
         [Fact]
@@ -128,12 +134,18 @@ namespace Microsoft.Data.SQLite
         }
 
         [Fact]
-        public void ExecuteNonQuery_throws_when_disposed()
+        public void ExecuteNonQuery_can_be_called_when_disposed()
         {
-            var command = new SQLiteCommand();
-            command.Dispose();
+            using (var connection = new SQLiteConnection("Filename=test.db"))
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT 1";
+                command.Dispose();
+                command.Connection = connection;
+                connection.Open();
 
-            Assert.Throws<ObjectDisposedException>(() => command.ExecuteNonQuery());
+                command.ExecuteNonQuery();
+            }
         }
 
         [Fact]

--- a/test/Microsoft.Data.SQLite.Tests/SQLiteConnectionTest.cs
+++ b/test/Microsoft.Data.SQLite.Tests/SQLiteConnectionTest.cs
@@ -100,12 +100,14 @@ namespace Microsoft.Data.SQLite
         }
 
         [Fact]
-        public void Open_throws_when_disposed()
+        public void Open_can_be_called_when_disposed()
         {
-            var connection = new SQLiteConnection("Filename=test.db");
-            connection.Dispose();
+            using (var connection = new SQLiteConnection("Filename=test.db"))
+            {
+                connection.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => connection.Open());
+                connection.Open();
+            }
         }
 
         [Fact]

--- a/test/Microsoft.Data.SQLite.Tests/packages.config
+++ b/test/Microsoft.Data.SQLite.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Data.Common" version="0.1-alpha-029" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This was recommended by @AndriySvyryd. None of the security attributes for this pattern were applied since they don't exist in Core CLR.
