### PR TITLE
Call sqlite3_clear_bindings when re-binding parameters

### DIFF
--- a/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
@@ -75,6 +75,9 @@ namespace Microsoft.Data.SQLite.Interop
         public static extern int sqlite3_changes(DatabaseHandle db);
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern int sqlite3_clear_bindings(StatementHandle pStmt);
+
+        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int sqlite3_close_v2(IntPtr db);
 
         [DllImport("sqlite3", EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -107,7 +110,6 @@ namespace Microsoft.Data.SQLite.Interop
         {
             return MarshalEx.PtrToStringUTF8(sqlite3_column_text_raw(pStmt, iCol));
         }
-
 
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int sqlite3_column_type(StatementHandle pStmt, int iCol);

--- a/src/Microsoft.Data.SQLite/SQLiteCommand.cs
+++ b/src/Microsoft.Data.SQLite/SQLiteCommand.cs
@@ -165,8 +165,8 @@ namespace Microsoft.Data.SQLite
                 out tail);
             MarshalEx.ThrowExceptionForRC(rc);
 
-            // TODO: Handle this. Only the only first statement is compiled. This is what
-            //       remains uncompiled.
+            // TODO: Handle this. Only the first statement is compiled. This is what remains
+            //       uncompiled.
             Debug.Assert(string.IsNullOrEmpty(tail), "CommandText contains more than one statement.");
 
             _prepared = true;
@@ -277,7 +277,7 @@ namespace Microsoft.Data.SQLite
             if (_parameters == null || _parameters.Bound)
                 return;
 
-            var rc = NativeMethods.sqlite3_reset(_handle);
+            var rc = NativeMethods.sqlite3_clear_bindings(_handle);
             MarshalEx.ThrowExceptionForRC(rc);
 
             _parameters.Bind(_handle);

--- a/src/Microsoft.Data.SQLite/project.json
+++ b/src/Microsoft.Data.SQLite/project.json
@@ -20,6 +20,7 @@
         "System.Resources.ResourceManager": "4.0.0.0",
         "System.Runtime": "4.0.20.0",
         "System.Runtime.Extensions": "4.0.10.0",
+        "System.Runtime.Handles": "4.0.0.0",
         "System.Runtime.InteropServices": "4.0.20.0",
         "System.Text.Encoding": "4.0.20.0"
       }

--- a/test/Microsoft.Data.SQLite.Tests/Utilities/TypeMapTest.cs
+++ b/test/Microsoft.Data.SQLite.Tests/Utilities/TypeMapTest.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Data.SQLite.Utilities
         }
 
         [Theory]
-        [InlineData(3.0)]
-        [InlineData(3.0f)]
+        [InlineData(3.14)]
+        [InlineData(3.14f)]
         public void FromClrType_maps_floats(object value)
         {
             var map = TypeMap.FromClrType(value);
 
             Assert.Equal(SQLiteType.Float, map.SQLiteType);
-            Assert.Equal(3.0, map.ToInterop(value));
+            Assert.Equal(3.14, (double)map.ToInterop(value), precision: 6);
         }
 
         [Fact]

--- a/test/Microsoft.Data.SQLite.Tests/project.json
+++ b/test/Microsoft.Data.SQLite.Tests/project.json
@@ -1,5 +1,4 @@
 {
-    "version": "0.1-alpha-*",
     "dependencies": {
         "Microsoft.Data.SQLite": "",
         "System.Data.Common": "0.1-alpha-*",


### PR DESCRIPTION
Prevents stale values from being used when parameters are removed.
