### PR TITLE
Marshalling strings through the fence posts

### DIFF
--- a/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.SQLite/Interop/NativeMethods.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Data.SQLite.Interop
 
         public static int sqlite3_bind_text(StatementHandle pStmt, int i, string zData)
         {
-            int n;
-            var ptr = MarshalEx.StringToHGlobalUTF8(zData, out n);
+            int size;
+            var ptr = MarshalEx.StringToHGlobalUTF8(zData, out size);
             try
             {
-                return sqlite3_bind_text(pStmt, i, ptr, n, Constants.SQLITE_TRANSIENT);
+                return sqlite3_bind_text(pStmt, i, ptr, size - 1, Constants.SQLITE_TRANSIENT);
             }
             finally
             {

--- a/test/Microsoft.Data.SQLite.Tests/SQLiteParameterTest.cs
+++ b/test/Microsoft.Data.SQLite.Tests/SQLiteParameterTest.cs
@@ -224,6 +224,22 @@ namespace Microsoft.Data.SQLite
         }
 
         [Fact]
+        public void Bind_binds_text_values_without_embedded_nulls()
+        {
+            using (var connection = new SQLiteConnection("Filename=:memory:"))
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT @Text || 'ing'";
+                command.Parameters.AddWithValue("@Text", "test");
+                connection.Open();
+
+                var result = command.ExecuteScalar();
+
+                Assert.Equal("testing", result);
+            }
+        }
+
+        [Fact]
         public void Bind_binds_blob_values()
         {
             using (var connection = new SQLiteConnection("Filename=:memory:"))


### PR DESCRIPTION
Don't embed nulls in string parameter values
