### PR TITLE
Return DBNull values from SQLiteDataReader

### DIFF
--- a/src/Microsoft.Data.SQLite/Utilities/ColumnReader.cs
+++ b/src/Microsoft.Data.SQLite/Utilities/ColumnReader.cs
@@ -13,11 +13,12 @@ namespace Microsoft.Data.SQLite.Utilities
         {
             Debug.Assert(handle != null && !handle.IsInvalid, "handle is null.");
 
+            if (sqliteType == SQLiteType.Null
+                    || NativeMethods.sqlite3_column_type(handle, ordinal) == Constants.SQLITE_NULL)
+                return DBNull.Value;
+
             switch (sqliteType)
             {
-                case SQLiteType.Null:
-                    return DBNull.Value;
-
                 case SQLiteType.Integer:
                     return NativeMethods.sqlite3_column_int64(handle, ordinal);
 

--- a/test/Microsoft.Data.SQLite.Tests/SQLiteDataReaderTest.cs
+++ b/test/Microsoft.Data.SQLite.Tests/SQLiteDataReaderTest.cs
@@ -702,6 +702,27 @@ namespace Microsoft.Data.SQLite
         }
 
         [Fact]
+        public void GetFieldValue_throws_when_null()
+        {
+            using (var connection = new SQLiteConnection("Filename=:memory:"))
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT NULL";
+                connection.Open();
+
+                using (var reader = command.ExecuteReader())
+                {
+                    reader.Read();
+
+                    Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<long>(0));
+                    Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<double>(0));
+                    Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<string>(0));
+                    Assert.Throws<InvalidCastException>(() => reader.GetFieldValue<byte[]>(0));
+                }
+            }
+        }
+
+        [Fact]
         public void GetValue_throws_when_closed()
         {
             var reader = CreateReader();


### PR DESCRIPTION
With out this, NULL values are converted to `0` or `null` during read. IsDBNull works as expected.
