### PR TITLE
Add shared-cache connection option

### DIFF
--- a/src/Microsoft.Data.Sqlite/CacheMode.cs
+++ b/src/Microsoft.Data.Sqlite/CacheMode.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+namespace Microsoft.Data.Sqlite
+{
+    public enum CacheMode
+    {
+        // TODO consider adding a 'default' or 'unspecified' mode
+        Private,
+        Shared
+    }
+}

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
@@ -168,7 +168,10 @@ namespace Microsoft.Data.Sqlite.Interop
                 }
             }
         }
-        
+
+        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int sqlite3_enable_shared_cache(bool enabled);
+
         [DllImport("sqlite3", EntryPoint = "sqlite3_errmsg16", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr sqlite3_errmsg16_raw(Sqlite3Handle db);
 

--- a/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
@@ -75,6 +75,22 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
+        /// The cache mode '{mode}' is invalid.
+        /// </summary>
+        internal static string InvalidCacheMode
+        {
+            get { return GetString("InvalidCacheMode"); }
+        }
+
+        /// <summary>
+        /// The cache mode '{mode}' is invalid.
+        /// </summary>
+        internal static string FormatInvalidCacheMode(object mode)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidCacheMode", "mode"), mode);
+        }
+
+        /// <summary>
         /// The CommandBehavior '{behavior}' is invalid.
         /// </summary>
         internal static string InvalidCommandBehavior
@@ -120,6 +136,22 @@ namespace Microsoft.Data.Sqlite
         internal static string FormatInvalidIsolationLevel(object isolationLevel)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidIsolationLevel", "isolationLevel"), isolationLevel);
+        }
+
+        /// <summary>
+        /// The IsolationLevel '{isolationLevel}' is invalid when the connection is not using Shared Cache mode.
+        /// </summary>
+        internal static string InvalidIsolationLevelForUnsharedCache
+        {
+            get { return GetString("InvalidIsolationLevelForUnsharedCache"); }
+        }
+
+        /// <summary>
+        /// The IsolationLevel '{isolationLevel}' is invalid when the connection is not using Shared Cache mode.
+        /// </summary>
+        internal static string FormatInvalidIsolationLevelForUnsharedCache(object isolationLevel)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidIsolationLevelForUnsharedCache", "isolationLevel"), isolationLevel);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.Sqlite/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteConnection.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Sqlite
 
         internal virtual Sqlite3Handle DbHandle => _db;
 
-        public virtual IntPtr Handle => _db.DangerousGetHandle();
+        public virtual IntPtr Handle => _db?.DangerousGetHandle() ?? IntPtr.Zero;
 
         public override string ConnectionString
         {
@@ -87,6 +87,7 @@ namespace Microsoft.Data.Sqlite
                 return;
             }
 
+            Transaction?.Dispose();
             _db.Dispose();
             _db = null;
             SetState(ConnectionState.Closed);
@@ -98,6 +99,8 @@ namespace Microsoft.Data.Sqlite
             {
                 Close();
             }
+
+            base.Dispose(disposing);
         }
 
         // NB: Other providers don't set Transaction

--- a/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
-        public virtual IntPtr Handle => _stmt.DangerousGetHandle();
+        public virtual IntPtr Handle => _stmt?.DangerousGetHandle() ?? IntPtr.Zero;
 
         public override bool HasRows => _hasRows;
         public override bool IsClosed => _closed;

--- a/src/Microsoft.Data.Sqlite/SqliteTransaction.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteTransaction.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Data.Sqlite
 
             if (isolationLevel == IsolationLevel.ReadUncommitted)
             {
+                if (connection.ConnectionStringBuilder.CacheMode != CacheMode.Shared)
+                {
+                    throw new ArgumentException(Strings.FormatInvalidIsolationLevelForUnsharedCache(isolationLevel));
+                }
                 connection.ExecuteNonQuery("PRAGMA read_uncommitted = 1;");
             }
             else if (isolationLevel == IsolationLevel.Serializable)

--- a/src/Microsoft.Data.Sqlite/Strings.resx
+++ b/src/Microsoft.Data.Sqlite/Strings.resx
@@ -129,6 +129,9 @@
   <data name="DataReaderClosed" xml:space="preserve">
     <value>Invalid attempt to call {operation} when reader is closed.</value>
   </data>
+  <data name="InvalidCacheMode" xml:space="preserve">
+    <value>The cache mode '{mode}' is invalid.</value>
+  </data>
   <data name="InvalidCommandBehavior" xml:space="preserve">
     <value>The CommandBehavior '{behavior}' is invalid.</value>
   </data>
@@ -137,6 +140,9 @@
   </data>
   <data name="InvalidIsolationLevel" xml:space="preserve">
     <value>The IsolationLevel '{isolationLevel}' is invalid.</value>
+  </data>
+  <data name="InvalidIsolationLevelForUnsharedCache" xml:space="preserve">
+    <value>The IsolationLevel '{isolationLevel}' can only be used with a shared cache. Set 'Cached=Shared' in the connection string.</value>
   </data>
   <data name="InvalidParameterDirection" xml:space="preserve">
     <value>The ParameterDirection '{direction}' is invalid.</value>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
@@ -15,6 +15,14 @@ namespace Microsoft.Data.Sqlite
             var builder = new SqliteConnectionStringBuilder("Data Source=test.db");
 
             Assert.Equal("test.db", builder.DataSource);
+            Assert.Equal(CacheMode.Private, builder.CacheMode);
+        }
+
+        [Fact]
+        public void Ctor_parses_SharedCache()
+        {
+            Assert.Equal(CacheMode.Private, new SqliteConnectionStringBuilder("Cache=Private").CacheMode);
+            Assert.Equal(CacheMode.Shared, new SqliteConnectionStringBuilder("Cache=Shared").CacheMode);
         }
 
         [Fact]
@@ -34,13 +42,27 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void CacheMode_throws_when_invalid_mode()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new SqliteConnectionStringBuilder("Cache=Valley"));
+            Assert.Equal(Strings.FormatInvalidCacheMode("Valley"), ex.Message);
+        }
+
+        [Fact]
+        public void CacheMode_defaults_to_private()
+        {
+            Assert.Equal(CacheMode.Private, new SqliteConnectionStringBuilder().CacheMode);
+        }
+
+        [Fact]
         public void Keys_works()
         {
             var keys = (ICollection<string>)new SqliteConnectionStringBuilder().Keys;
 
             Assert.True(keys.IsReadOnly);
-            Assert.Equal(1, keys.Count);
+            Assert.Equal(2, keys.Count);
             Assert.Contains("Data Source", keys);
+            Assert.Contains("Cache", keys);
         }
 
         [Fact]
@@ -49,7 +71,7 @@ namespace Microsoft.Data.Sqlite
             var values = (ICollection<object>)new SqliteConnectionStringBuilder().Values;
 
             Assert.True(values.IsReadOnly);
-            Assert.Equal(1, values.Count);
+            Assert.Equal(2, values.Count);
         }
 
         [Fact]
@@ -172,5 +194,19 @@ namespace Microsoft.Data.Sqlite
             Assert.True(retrieved);
             Assert.Equal("test.db", value);
         }
+
+        [Fact]
+        public void ToString_builds_string()
+        {
+            var builder = new SqliteConnectionStringBuilder
+            {
+                DataSource = "test.db",
+                CacheMode = CacheMode.Shared
+            };
+            Assert.Equal("Data Source=test.db;Cache=Shared", builder.ToString());
+
+            Assert.Equal("Data Source=test2.db", new SqliteConnectionStringBuilder(" Data Source = test2.db ").ToString());
+        }
+
     }
 }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteTransactionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteTransactionTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Ctor_sets_read_uncommitted()
         {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            using (var connection = new SqliteConnection("Data Source=:memory:;Cache=Shared"))
             {
                 connection.Open();
 
@@ -50,6 +50,24 @@ namespace Microsoft.Data.Sqlite
                 Assert.Equal(Strings.FormatInvalidIsolationLevel(IsolationLevel.Snapshot), ex.Message);
             }
         }
+
+        [Fact]
+        public void Ctor_throws_when_invalid_isolation_level_without_cache()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+               var ex =  Assert.Throws<ArgumentException>(()=>connection.BeginTransaction(IsolationLevel.ReadUncommitted));
+                Assert.Equal(Strings.FormatInvalidIsolationLevelForUnsharedCache(IsolationLevel.ReadUncommitted), ex.Message);
+            }
+
+            using (var connection = new SqliteConnection("Data Source=:memory:;Cache=Shared"))
+            {
+                connection.Open();
+                connection.BeginTransaction(IsolationLevel.ReadUncommitted);
+            }
+        }
+
 
         [Fact]
         public void IsolationLevel_throws_when_completed()


### PR DESCRIPTION
Add option to enable shared-cache on new connections.
https://www.sqlite.org/sharedcache.html


Also improves the calls added to #82 