### PR TITLE
Use sqlite3_open_v2 instead && use UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.db
 *.suo
 *.user
@@ -9,6 +10,7 @@
 bin/
 obj/
 project.lock.json
+.settings
 
 # Ignore vagrant - used for cross-platform testing
 .vagrant/

--- a/src/Microsoft.Data.Sqlite/Interop/Constants.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Constants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Sqlite.Interop
     internal static class Constants
     {
         public const int SQLITE_OK = 0;
-
+        
         public const int SQLITE_ROW = 100;
         public const int SQLITE_DONE = 101;
 
@@ -17,6 +17,12 @@ namespace Microsoft.Data.Sqlite.Interop
         public const int SQLITE_TEXT = 3;
         public const int SQLITE_BLOB = 4;
         public const int SQLITE_NULL = 5;
+        
+        public const int SQLITE_OPEN_SHAREDCACHE = 0x00020000;
+        public const int SQLITE_OPEN_PRIVATECACHE = 0x00040000;
+        public const int SQLITE_OPEN_READWRITE = 0x00000002;
+        public const int SQLITE_OPEN_CREATE = 0x00000004;
+        
 
         public static readonly IntPtr SQLITE_TRANSIENT = new IntPtr(-1);
     }

--- a/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
@@ -28,10 +28,11 @@ namespace Microsoft.Data.Sqlite.Interop
             return Encoding.UTF8.GetString(bytes, 0, i);
         }
 
-        public static IntPtr StringToHGlobalUTF8(string s)
+        public static IntPtr StringToHGlobalUTF8(string s, out int length)
         {
             if (s == null)
             {
+                length = 0;
                 return IntPtr.Zero;
             }
 
@@ -39,8 +40,15 @@ namespace Microsoft.Data.Sqlite.Interop
             var ptr = Marshal.AllocHGlobal(bytes.Length + 1);
             Marshal.Copy(bytes, 0, ptr, bytes.Length);
             Marshal.WriteByte(ptr, bytes.Length, 0);
+            length = bytes.Length;
 
             return ptr;
+        }
+
+        public static IntPtr StringToHGlobalUTF8(string s)
+        {
+            int temp;
+            return StringToHGlobalUTF8(s, out temp);
         }
 
         public static void ThrowExceptionForRC(int rc, Sqlite3Handle db)
@@ -54,7 +62,7 @@ namespace Microsoft.Data.Sqlite.Interop
 
             var message = db == null || db.IsInvalid
                 ? NativeMethods.sqlite3_errstr(rc)
-                : NativeMethods.sqlite3_errmsg16(db);
+                : NativeMethods.sqlite3_errmsg(db);
 
             throw new SqliteException("Error: " + message, rc);
         }

--- a/src/Microsoft.Data.Sqlite/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite.Interop;
@@ -111,10 +112,9 @@ namespace Microsoft.Data.Sqlite
             do
             {
                 Sqlite3StmtHandle stmt;
-                var rc = NativeMethods.sqlite3_prepare16_v2(
+                var rc = NativeMethods.sqlite3_prepare_v2(
                     Connection.DbHandle,
                     tail,
-                    -1,
                     out stmt,
                     out tail);
                 MarshalEx.ThrowExceptionForRC(rc, Connection.DbHandle);

--- a/src/Microsoft.Data.Sqlite/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteConnection.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Strings.OpenRequiresSetConnectionString);
             }
 
-            var rc = NativeMethods.sqlite3_enable_shared_cache(ConnectionStringBuilder.CacheMode == CacheMode.Shared); // called to ensure mode set correctly before a connection is created
-            MarshalEx.ThrowExceptionForRC(rc, _db);
+            var flags = Constants.SQLITE_OPEN_READWRITE | Constants.SQLITE_OPEN_CREATE;
+            flags |= (ConnectionStringBuilder.CacheMode == CacheMode.Shared) ? Constants.SQLITE_OPEN_SHAREDCACHE : Constants.SQLITE_OPEN_PRIVATECACHE;
 
-            rc = NativeMethods.sqlite3_open16(ConnectionStringBuilder.DataSource, out _db);
+            var rc = NativeMethods.sqlite3_open_v2(ConnectionStringBuilder.DataSource, out _db, flags, vfs: null);
             MarshalEx.ThrowExceptionForRC(rc, _db);
             SetState(ConnectionState.Open);
         }

--- a/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Strings.FormatDataReaderClosed("GetName"));
             }
 
-            var name = NativeMethods.sqlite3_column_name16(_stmt, ordinal);
+            var name = NativeMethods.sqlite3_column_name(_stmt, ordinal);
             if (name == null
                 && (ordinal < 0 || ordinal >= FieldCount))
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Strings.FormatDataReaderClosed("GetDataTypeName"));
             }
 
-            var typeName = NativeMethods.sqlite3_column_decltype16(_stmt, ordinal);
+            var typeName = NativeMethods.sqlite3_column_decltype(_stmt, ordinal);
             if (typeName != null)
             {
                 var i = typeName.IndexOf('(');
@@ -320,7 +320,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidCastException();
             }
 
-            return NativeMethods.sqlite3_column_text16(_stmt, ordinal);
+            return NativeMethods.sqlite3_column_text(_stmt, ordinal);
         }
 
         public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)

--- a/src/Microsoft.Data.Sqlite/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteParameter.cs
@@ -252,6 +252,6 @@ namespace Microsoft.Data.Sqlite
             NativeMethods.sqlite3_bind_blob(stmt, index, value, value.Length, Constants.SQLITE_TRANSIENT);
 
         private static void BindText(Sqlite3StmtHandle stmt, int index, string value) =>
-            NativeMethods.sqlite3_bind_text16(stmt, index, value, value.Length * 2, Constants.SQLITE_TRANSIENT);
+            NativeMethods.sqlite3_bind_text(stmt, index, value, value.Length, Constants.SQLITE_TRANSIENT);
     }
 }


### PR DESCRIPTION
This allows shared_cache on OS X and iPhone. Also it has the advantage of setting Cache=Shared only for the currently opened connection and does not tamper with global settings.

Fixes #88.