### PR TITLE
Fix memory leak.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 obj/
 project.lock.json
 .settings
+*.sublime-*
 
 # Ignore vagrant - used for cross-platform testing
 .vagrant/

--- a/src/Microsoft.Data.Sqlite/Interop/Constants.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Constants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Sqlite.Interop
     internal static class Constants
     {
         public const int SQLITE_OK = 0;
-        
+
         public const int SQLITE_ROW = 100;
         public const int SQLITE_DONE = 101;
 
@@ -17,12 +17,11 @@ namespace Microsoft.Data.Sqlite.Interop
         public const int SQLITE_TEXT = 3;
         public const int SQLITE_BLOB = 4;
         public const int SQLITE_NULL = 5;
-        
+
         public const int SQLITE_OPEN_SHAREDCACHE = 0x00020000;
         public const int SQLITE_OPEN_PRIVATECACHE = 0x00040000;
         public const int SQLITE_OPEN_READWRITE = 0x00000002;
         public const int SQLITE_OPEN_CREATE = 0x00000004;
-        
 
         public static readonly IntPtr SQLITE_TRANSIENT = new IntPtr(-1);
     }

--- a/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Sqlite.Interop
                 ? NativeMethods.sqlite3_errstr(rc)
                 : NativeMethods.sqlite3_errmsg(db);
 
-            throw new SqliteException("Error: " + message, rc);
+            throw new SqliteException(Strings.FormatSqliteNativeError(rc, message), rc);
         }
     }
 }

--- a/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
-        /// The IsolationLevel '{isolationLevel}' is invalid when the connection is not using Shared Cache mode.
+        /// The IsolationLevel '{isolationLevel}' can only be used with a shared cache. Set 'Cached=Shared' in the connection string.
         /// </summary>
         internal static string InvalidIsolationLevelForUnsharedCache
         {
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
-        /// The IsolationLevel '{isolationLevel}' is invalid when the connection is not using Shared Cache mode.
+        /// The IsolationLevel '{isolationLevel}' can only be used with a shared cache. Set 'Cached=Shared' in the connection string.
         /// </summary>
         internal static string FormatInvalidIsolationLevelForUnsharedCache(object isolationLevel)
         {
@@ -344,6 +344,22 @@ namespace Microsoft.Data.Sqlite
         internal static string FormatUnknownDataType(object typeName)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("UnknownDataType", "typeName"), typeName);
+        }
+
+        /// <summary>
+        /// SQLite Error {errorCode}: '{message}'.
+        /// </summary>
+        internal static string SqliteNativeError
+        {
+            get { return GetString("SqliteNativeError"); }
+        }
+
+        /// <summary>
+        /// SQLite Error {errorCode}: '{message}'.
+        /// </summary>
+        internal static string FormatSqliteNativeError(object errorCode, object message)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SqliteNativeError", "errorCode", "message"), errorCode, message);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.Data.Sqlite/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteCommand.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Sqlite.Interop;
@@ -156,7 +155,15 @@ namespace Microsoft.Data.Sqlite
                 }
 
                 rc = NativeMethods.sqlite3_step(stmt);
-                MarshalEx.ThrowExceptionForRC(rc, Connection.DbHandle);
+                try
+                {
+                    MarshalEx.ThrowExceptionForRC(rc, Connection.DbHandle);
+                }
+                catch
+                {
+                    stmt.Dispose();
+                    throw;
+                }
 
                 // NB: This is only a heuristic to separate SELECT statements from INSERT/UPDATE/DELETE statements. It will result
                 //     in unexpected corner cases, but it's the best we can do without re-parsing SQL

--- a/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Data.Sqlite.Interop;
 using Microsoft.Data.Sqlite.Utilities;
+using static Microsoft.Data.Sqlite.Interop.Constants;
 #if NET45 || DNX451
 using System.Data;
 
@@ -96,7 +97,7 @@ namespace Microsoft.Data.Sqlite
             var rc = NativeMethods.sqlite3_step(_stmt);
             MarshalEx.ThrowExceptionForRC(rc, _db);
 
-            _done = rc == Constants.SQLITE_DONE;
+            _done = rc == SQLITE_DONE;
 
             return !_done;
         }
@@ -203,19 +204,19 @@ namespace Microsoft.Data.Sqlite
             var sqliteType = GetSqliteType(ordinal);
             switch (sqliteType)
             {
-                case Constants.SQLITE_INTEGER:
+                case SQLITE_INTEGER:
                     return "INTEGER";
 
-                case Constants.SQLITE_FLOAT:
+                case SQLITE_FLOAT:
                     return "REAL";
 
-                case Constants.SQLITE_TEXT:
+                case SQLITE_TEXT:
                     return "TEXT";
 
-                case Constants.SQLITE_BLOB:
+                case SQLITE_BLOB:
                     return "BLOB";
 
-                case Constants.SQLITE_NULL:
+                case SQLITE_NULL:
                     return "INTEGER";
 
                 default:
@@ -234,19 +235,19 @@ namespace Microsoft.Data.Sqlite
             var sqliteType = GetSqliteType(ordinal);
             switch (sqliteType)
             {
-                case Constants.SQLITE_INTEGER:
+                case SQLITE_INTEGER:
                     return typeof(long);
 
-                case Constants.SQLITE_FLOAT:
+                case SQLITE_FLOAT:
                     return typeof(double);
 
-                case Constants.SQLITE_TEXT:
+                case SQLITE_TEXT:
                     return typeof(string);
 
-                case Constants.SQLITE_BLOB:
+                case SQLITE_BLOB:
                     return typeof(byte[]);
 
-                case Constants.SQLITE_NULL:
+                case SQLITE_NULL:
                     return typeof(int);
 
                 default:
@@ -258,7 +259,7 @@ namespace Microsoft.Data.Sqlite
         private int GetSqliteType(int ordinal)
         {
             var type = NativeMethods.sqlite3_column_type(_stmt, ordinal);
-            if (type == Constants.SQLITE_NULL
+            if (type == SQLITE_NULL
                 && (ordinal < 0 || ordinal >= FieldCount))
             {
                 // NB: Message is provided by the framework
@@ -279,7 +280,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Strings.NoData);
             }
 
-            return GetSqliteType(ordinal) == Constants.SQLITE_NULL;
+            return GetSqliteType(ordinal) == SQLITE_NULL;
         }
 
         public override bool GetBoolean(int ordinal) => GetInt64(ordinal) != 0;
@@ -435,19 +436,19 @@ namespace Microsoft.Data.Sqlite
             var sqliteType = GetSqliteType(ordinal);
             switch (sqliteType)
             {
-                case Constants.SQLITE_INTEGER:
+                case SQLITE_INTEGER:
                     return GetInt64(ordinal);
 
-                case Constants.SQLITE_FLOAT:
+                case SQLITE_FLOAT:
                     return GetDouble(ordinal);
 
-                case Constants.SQLITE_TEXT:
+                case SQLITE_TEXT:
                     return GetString(ordinal);
 
-                case Constants.SQLITE_BLOB:
+                case SQLITE_BLOB:
                     return GetBlob(ordinal);
 
-                case Constants.SQLITE_NULL:
+                case SQLITE_NULL:
                     if (!_stepped || _done)
                     {
                         throw new InvalidOperationException(Strings.NoData);

--- a/src/Microsoft.Data.Sqlite/Strings.resx
+++ b/src/Microsoft.Data.Sqlite/Strings.resx
@@ -180,4 +180,7 @@
   <data name="UnknownDataType" xml:space="preserve">
     <value>No mapping exists from object type {typeName} to a known managed provider native type.</value>
   </data>
+  <data name="SqliteNativeError" xml:space="preserve">
+    <value>SQLite Error {errorCode}: '{message}'</value>
+  </data>
 </root>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using System.IO;
+using Microsoft.Data.Sqlite.Interop;
+using Xunit;
+
+namespace Microsoft.Data.Sqlite
+{
+    public class SqliteConcurrencyTest : IDisposable
+    {
+        private const int SQLITE_BUSY = 5;
+        private const int SQLITE_LOCKED = 6;
+
+        public SqliteConcurrencyTest()
+        {
+            using (var connection = CreateConnection())
+            {
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText = @"CREATE TABLE IF NOT EXISTS a (b);
+INSERT INTO a VALUES (1);
+INSERT INTO a VALUES (2);";
+                command.ExecuteNonQuery();
+            }
+        }
+
+        [Fact]
+        public void It_throws_sqlite_locked()
+        {
+            using (var connection = CreateConnection())
+            {
+                var selectCommand = connection.CreateCommand();
+                connection.Open();
+                selectCommand.CommandText = "SELECT * FROM a;";
+
+                var insertCommand = connection.CreateCommand();
+                insertCommand.CommandText = "DROP TABLE a;";
+
+                using (var reader = selectCommand.ExecuteReader())
+                {
+                    reader.Read();
+                    var ex = Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+
+                    Assert.Equal(SQLITE_LOCKED, ex.SqliteErrorCode);
+                    var message = NativeMethods.sqlite3_errstr(SQLITE_LOCKED);
+                    Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_LOCKED, message), ex.Message);
+                }
+
+                insertCommand.ExecuteNonQuery();
+                Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+            }
+        }
+
+        [Fact]
+        public void It_throws_sqlite_busy()
+        {
+            using (var connection = CreateConnection())
+            {
+                var selectCommand = connection.CreateCommand();
+                connection.Open();
+                selectCommand.CommandText = "SELECT * FROM a;";
+                using (var connection2 = CreateConnection())
+                {
+                    var insertCommand = connection2.CreateCommand();
+                    connection2.Open();
+                    insertCommand.CommandText = "DROP TABLE a;";
+                    using (var reader = selectCommand.ExecuteReader())
+                    {
+                        reader.Read();
+                        var ex = Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+
+                        Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+                        var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
+                        Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                    }
+
+                    insertCommand.ExecuteNonQuery();
+                    Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+                }
+            }
+        }
+
+        private const string FileName = "./concurrency.db";
+
+        private DbConnection CreateConnection() => new SqliteConnection("Data Source=" + FileName);
+
+        public void Dispose()
+        {
+            if (File.Exists(FileName))
+            {
+                File.Delete(FileName);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Data.Sqlite.Tests/project.json
+++ b/test/Microsoft.Data.Sqlite.Tests/project.json
@@ -9,6 +9,8 @@
     },
     "frameworks": {
         "dnx451": { },
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "System.IO.FileSystem": " 4.0.0-*"
+        }
     }
 }


### PR DESCRIPTION
When a SQLite statement causes an error sqlite3_step, the statement object was not disposed.

Add test cases to replicate https://github.com/aspnet/EntityFramework/issues/2356.

Improved error messages for SQL errors