### PR TITLE
Implement command timeouts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.db
+*.db-journal
 *.suo
 *.user
 /.nuget/

--- a/src/Microsoft.Data.Sqlite/Interop/Constants.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Constants.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Data.Sqlite.Interop
         public const int SQLITE_OPEN_READWRITE = 0x00000002;
         public const int SQLITE_OPEN_CREATE = 0x00000004;
 
+
+        public const int SQLITE_BUSY = 5;
+        public const int SQLITE_LOCKED = 6;
+        
         public static readonly IntPtr SQLITE_TRANSIENT = new IntPtr(-1);
     }
 }

--- a/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
-        /// SQLite Error {errorCode}: '{message}'.
+        /// SQLite Error {errorCode}: '{message}'
         /// </summary>
         internal static string SqliteNativeError
         {
@@ -355,7 +355,7 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
-        /// SQLite Error {errorCode}: '{message}'.
+        /// SQLite Error {errorCode}: '{message}'
         /// </summary>
         internal static string FormatSqliteNativeError(object errorCode, object message)
         {

--- a/src/Microsoft.Data.Sqlite/project.json
+++ b/src/Microsoft.Data.Sqlite/project.json
@@ -23,6 +23,7 @@
                 "System.IO.FileSystem": "4.0.0-*",
                 "System.Linq": "4.0.0-*",
                 "System.Runtime.InteropServices": "4.0.20-*",
+                "System.Threading.Thread": "4.0.0-*",
                 "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
                 "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*"
             }
@@ -35,6 +36,7 @@
                 "System.Reflection": "4.0.10-*",
                 "System.Runtime.InteropServices": "4.0.20-*",
                 "System.Text.Encoding": "4.0.10-*",
+                "System.Threading.Thread": "4.0.0-*",
                 "System.Threading.Tasks": "4.0.10-*"
             }
         }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
@@ -2,18 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.Common;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.Sqlite.Interop;
 using Xunit;
+using static Microsoft.Data.Sqlite.Interop.Constants;
 
 namespace Microsoft.Data.Sqlite
 {
     public class SqliteConcurrencyTest : IDisposable
     {
-        private const int SQLITE_BUSY = 5;
-        private const int SQLITE_LOCKED = 6;
-
         public SqliteConcurrencyTest()
         {
             using (var connection = CreateConnection())
@@ -27,8 +28,47 @@ INSERT INTO a VALUES (2);";
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Multi_threaded_access_avoids_locking_and_busy(bool sharedCache)
+        {
+            var list = new List<Action>();
+            for (var i = 0; i < 50; i++)
+            {
+                var copy_i = i;
+                list.Add(() =>
+                    {
+                        using (var connection = CreateConnection(shared: sharedCache))
+                        {
+                            connection.Open();
+                            var command = connection.CreateCommand();
+                            command.CommandTimeout = 30;
+                            if (copy_i % 2 == 0)
+                            {
+                                command.CommandText = "SELECT * FROM a;";
+                                using (var reader = command.ExecuteReader())
+                                {
+                                    while (reader.Read())
+                                    {
+                                        ;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                command.CommandText = "INSERT INTO a VALUES ( 1);";
+                                Assert.Equal(1, command.ExecuteNonQuery());
+                            }
+                        }
+                    });
+            }
+            var tasks = list.Select(execute => Task.Factory.StartNew(execute)).ToArray();
+            Task.WaitAll(tasks);
+        }
+
         [Fact]
-        public void It_throws_sqlite_locked()
+        public void It_throws_drop_table_deadlock()
         {
             using (var connection = CreateConnection())
             {
@@ -36,26 +76,27 @@ INSERT INTO a VALUES (2);";
                 connection.Open();
                 selectCommand.CommandText = "SELECT * FROM a;";
 
-                var insertCommand = connection.CreateCommand();
-                insertCommand.CommandText = "DROP TABLE a;";
+                var dropCommand = connection.CreateCommand();
+                dropCommand.CommandTimeout = 10;
+                dropCommand.CommandText = "DROP TABLE a;";
 
                 using (var reader = selectCommand.ExecuteReader())
                 {
                     reader.Read();
-                    var ex = Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+                    var ex = Assert.Throws<SqliteException>(() => dropCommand.ExecuteNonQuery());
 
                     Assert.Equal(SQLITE_LOCKED, ex.SqliteErrorCode);
-                    var message = NativeMethods.sqlite3_errstr(SQLITE_LOCKED);
+                    var message = NativeMethods.sqlite3_errmsg(connection.DbHandle);
                     Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_LOCKED, message), ex.Message);
                 }
 
-                insertCommand.ExecuteNonQuery();
-                Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+                dropCommand.ExecuteNonQuery();
+                Assert.Throws<SqliteException>(() => dropCommand.ExecuteNonQuery());
             }
         }
 
         [Fact]
-        public void It_throws_sqlite_busy()
+        public void It_throws_sqlite_busy_on_deadlock()
         {
             using (var connection = CreateConnection())
             {
@@ -64,28 +105,105 @@ INSERT INTO a VALUES (2);";
                 selectCommand.CommandText = "SELECT * FROM a;";
                 using (var connection2 = CreateConnection())
                 {
-                    var insertCommand = connection2.CreateCommand();
+                    var dropCommand = connection2.CreateCommand();
                     connection2.Open();
-                    insertCommand.CommandText = "DROP TABLE a;";
+                    dropCommand.CommandText = "DROP TABLE a;";
                     using (var reader = selectCommand.ExecuteReader())
                     {
                         reader.Read();
-                        var ex = Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+                        var ex = Assert.Throws<SqliteException>(() => dropCommand.ExecuteNonQuery());
 
                         Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
                         var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
                         Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
                     }
 
-                    insertCommand.ExecuteNonQuery();
-                    Assert.Throws<SqliteException>(() => insertCommand.ExecuteNonQuery());
+                    dropCommand.ExecuteNonQuery();
+                    Assert.Throws<SqliteException>(() => dropCommand.ExecuteNonQuery());
+                }
+            }
+        }
+
+        [Fact]
+        public void Prevents_timeout_exception()
+        {
+            using (var connection1 = CreateConnection())
+            {
+                using (var connection2 = CreateConnection())
+                {
+                    connection1.Open();
+                    connection2.Open();
+
+                    var selectCommand = connection1.CreateCommand();
+                    selectCommand.CommandTimeout = 30;
+                    selectCommand.CommandText = "SELECT * FROM a;";
+
+                    var insertCommand = connection2.CreateCommand();
+                    insertCommand.CommandTimeout = 10;
+                    insertCommand.CommandText = "INSERT INTO a VALUES ( 1);";
+
+                    var t1 = Task.Factory.StartNew(() =>
+                        {
+                            using (var reader = selectCommand.ExecuteReader())
+                            {
+                                Thread.Sleep(insertCommand.CommandTimeout * 1000 / 2); // delay task 2, but not beyond its timeout
+                            }
+                        });
+                    var t2 = Task.Factory.StartNew(() => { insertCommand.ExecuteNonQuery(); });
+                    Task.WaitAll(t1, t2);
+                }
+            }
+        }
+
+        [Fact]
+        public void Command_times_out()
+        {
+            using (var connection1 = CreateConnection())
+            {
+                using (var connection2 = CreateConnection())
+                {
+                    connection1.Open();
+                    connection2.Open();
+
+                    var selectCommand = connection1.CreateCommand();
+                    selectCommand.CommandText = "SELECT * FROM a;";
+
+                    var insertCommand = connection2.CreateCommand();
+                    insertCommand.CommandTimeout = 1;
+                    insertCommand.CommandText = "INSERT INTO a VALUES ( 1);";
+
+                    var waitHandle = new Semaphore(0,1);
+                    var beginRead = new Semaphore(0,1);
+                    var t1 = new Thread(() =>
+                        {
+                            using (var reader = selectCommand.ExecuteReader())
+                            {
+                                beginRead.Release();
+                                waitHandle.WaitOne();
+                            }
+                        });
+                    var t2 = new Thread(() =>
+                        {
+                            beginRead.WaitOne();
+                            var ex = Assert.Throws<SqliteException>(()=>insertCommand.ExecuteNonQuery());
+                            waitHandle.Release();
+                             
+                            Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
+                            var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
+                            Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                        });
+
+                    t1.Start();
+                    t2.Start();
+                    t1.Join();
+                    t2.Join();
                 }
             }
         }
 
         private const string FileName = "./concurrency.db";
 
-        private DbConnection CreateConnection() => new SqliteConnection("Data Source=" + FileName);
+        private SqliteConnection CreateConnection(bool shared = false) => new SqliteConnection($"Data Source={FileName};Cache={(shared ? "Shared" : "Private")}");
 
         public void Dispose()
         {


### PR DESCRIPTION
Implements a timeout option on the connection string. Default timeout = 30s

Users can modify this with the connection string `Data Source =test.db; Timeout=10 `

This handles SQLITE_LOCKED and SQLITE_BUSY, and throws a `TimeoutException` if they are not handled within the timeout specified in the connection string.

Works for both cache modes (Shared and Private).

TODO: perf

Fixes #97 