### PR TITLE
[testing] Fail all tests if sqlite3.dll cannot be imported

### DIFF
--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.xproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>69d2da13-6774-43a9-a2e3-709594136ff8</ProjectGuid>
@@ -12,7 +11,6 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
@@ -20,4 +18,9 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties xunit_1runner_1json__JSONSchema="http://xunit.github.io/schema/v2.1-rc1/xunit.runner.schema.json" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/TestUtilities/SqliteTestFramework.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/TestUtilities/SqliteTestFramework.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.Data.Sqlite.Interop;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Microsoft.Data.Sqlite.Tests.TestUtilities.SqliteTestFramework", "Microsoft.Data.Sqlite.Tests")]
+
+namespace Microsoft.Data.Sqlite.Tests.TestUtilities
+{
+    public class SqliteTestFramework : XunitTestFramework
+    {
+        private readonly IMessageSink _messageSink;
+
+        public SqliteTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+            _messageSink = messageSink;
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            _messageSink.OnMessage(new Xunit.Sdk.DiagnosticMessage
+            {
+                Message = $"Using SQLite v{NativeMethods.sqlite3_libversion()}"
+            });
+
+            return base.CreateExecutor(assemblyName);
+        }
+    }
+}

--- a/test/Microsoft.Data.Sqlite.Tests/xunit.runner.json
+++ b/test/Microsoft.Data.Sqlite.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "diagnosticMessages": true
+}


### PR DESCRIPTION
Add debugging info to display the version of SQLite used.

Currently, if sqlite3.dll cannot import, then we get 239 errors, all with the same message. This short-circuits and cancels all testing if sqlite3.dll does not import.
