### PR TITLE
Support SQLite 3.7.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: csharp
 sudo: false
+env:
+  - MONO_THREADS_PER_CPU=2000 MONO_MANAGED_WATCHER=disabled
 mono:
   - beta
 os:
   - linux
+  - osx
 
 addons:
   apt:
-    sources:
-    - debian-sid
     packages:
     - libunwind8
-    - sqlite3
-
+    
 before_script:
   - sqlite3 -version
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install icu4c; fi
 script:
   - ./build.sh --quiet verify

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contains SQLite implementations of the System.Data.Common interfaces.
 This project is part of ASP.NET 5. You can find samples, documentation and getting started instructions for ASP.NET 5 at the [Home](https://github.com/aspnet/home) repo.
 
 ## Requirements
-Requires SQLite >= 3.7.15
+Requires SQLite >= 3.7.9
 
 This library binds to the native SQLite library. On some systems, you must also install separately the SQLite library.
 

--- a/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
@@ -60,11 +60,7 @@ namespace Microsoft.Data.Sqlite.Interop
                 return;
             }
 
-            var message = db == null || db.IsInvalid
-                ? NativeMethods.sqlite3_errstr(rc)
-                : NativeMethods.sqlite3_errmsg(db);
-
-            throw new SqliteException(Strings.FormatSqliteNativeError(rc, message), rc);
+            throw new SqliteException(VersionedMethods.SqliteErrorMessage(rc, db), rc);
         }
     }
 }

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Data.Sqlite.Interop
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
         public static extern int sqlite3_close_v2(IntPtr db);
 
+        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int sqlite3_close(IntPtr db);
+
         [DllImport("sqlite3", EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr sqlite3_column_blob_raw(Sqlite3StmtHandle pStmt, int iCol);
 

--- a/src/Microsoft.Data.Sqlite/Interop/Sqlite3Handle.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Sqlite3Handle.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Sqlite.Interop
 
         protected override bool ReleaseHandle()
         {
-            var rc = NativeMethods.sqlite3_close_v2(handle);
+            var rc = VersionedMethods.SqliteClose(handle);
             handle = IntPtr.Zero;
 
             return rc == Constants.SQLITE_OK;

--- a/src/Microsoft.Data.Sqlite/Interop/VersionedMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/VersionedMethods.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Data.Sqlite.Interop
+{
+    internal class VersionedMethods
+    {
+        public static string SqliteErrorMessage(int rc, Sqlite3Handle db)
+        {
+            var message = db == null || db.IsInvalid
+                ? _strategy.ErrorString(rc)
+                : NativeMethods.sqlite3_errmsg(db);
+
+            return Strings.FormatSqliteNativeError(rc, message);
+        }
+
+        public static int SqliteClose(IntPtr handle)
+           => _strategy.Close(handle);
+
+        public static string SqliteDbFilename(Sqlite3Handle db, string databaseName)
+            => _strategy.DbFilename(db, databaseName);
+
+        private static readonly StrategyBase _strategy = GetStrategy(new Version(NativeMethods.sqlite3_libversion()));
+
+        private static StrategyBase GetStrategy(Version current)
+        {
+            if (current >= new Version("3.7.15"))
+            {
+                return new Strategy3_7_15();
+            }
+            if (current >= new Version("3.7.14"))
+            {
+                return new Strategy3_7_14();
+            }
+            if (current >= new Version("3.7.10"))
+            {
+                return new Strategy3_7_10();
+            }
+            return new StrategyBase();
+        }
+
+        private class Strategy3_7_15 : Strategy3_7_14
+        {
+            public override string ErrorString(int rc)
+                => NativeMethods.sqlite3_errstr(rc) + " " + base.ErrorString(rc);
+        }
+
+        private class Strategy3_7_14 : Strategy3_7_10
+        {
+            public override int Close(IntPtr handle)
+                => NativeMethods.sqlite3_close_v2(handle);
+        }
+
+        private class Strategy3_7_10 : StrategyBase
+        {
+            public override string DbFilename(Sqlite3Handle db, string databaseName)
+                => NativeMethods.sqlite3_db_filename(db, databaseName);
+        }
+
+        private class StrategyBase
+        {
+            public virtual string ErrorString(int rc)
+                => Strings.DefaultNativeError;
+                
+            public virtual int Close(IntPtr handle)
+                => NativeMethods.sqlite3_close(handle);
+                
+            public virtual string DbFilename(Sqlite3Handle db, string databaseName)
+                => null;
+        }
+    }
+}

--- a/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
@@ -362,6 +362,22 @@ namespace Microsoft.Data.Sqlite
             return string.Format(CultureInfo.CurrentCulture, GetString("SqliteNativeError", "errorCode", "message"), errorCode, message);
         }
 
+        /// <summary>
+        /// For more information on this error code see https://www.sqlite.org/rescode.html
+        /// </summary>
+        internal static string DefaultNativeError
+        {
+            get { return GetString("DefaultNativeError"); }
+        }
+
+        /// <summary>
+        /// For more information on this error code see https://www.sqlite.org/rescode.html
+        /// </summary>
+        internal static string FormatDefaultNativeError()
+        {
+            return GetString("DefaultNativeError");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Sqlite/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteConnection.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Data.Sqlite
 
         public override string DataSource =>
             State == ConnectionState.Open
-                ? NativeMethods.sqlite3_db_filename(_db, MainDatabaseName)
+                ? VersionedMethods.SqliteDbFilename(_db, MainDatabaseName) ?? ConnectionStringBuilder.DataSource
                 : ConnectionStringBuilder.DataSource;
 
         /// <summary>

--- a/src/Microsoft.Data.Sqlite/Strings.resx
+++ b/src/Microsoft.Data.Sqlite/Strings.resx
@@ -181,6 +181,9 @@
     <value>No mapping exists from object type {typeName} to a known managed provider native type.</value>
   </data>
   <data name="SqliteNativeError" xml:space="preserve">
-    <value>SQLite Error {errorCode}: '{message}'</value>
+    <value>SQLite Error {errorCode}: '{message}'.</value>
+  </data>
+  <data name="DefaultNativeError" xml:space="preserve">
+    <value>For more information on this error code see https://www.sqlite.org/rescode.html</value>
   </data>
 </root>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConcurrencyTest.cs
@@ -116,8 +116,12 @@ INSERT INTO a VALUES (2);";
                         var ex = Assert.Throws<SqliteException>(() => dropCommand.ExecuteNonQuery());
 
                         Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
-                        var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
-                        Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                        
+                        if (CurrentVersion >= new Version("3.7.15"))
+                        {
+                            var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
+                            Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                        }
                     }
 
                     dropCommand.ExecuteNonQuery();
@@ -191,8 +195,12 @@ INSERT INTO a VALUES (2);";
                             waitHandle.Release();
 
                             Assert.Equal(SQLITE_BUSY, ex.SqliteErrorCode);
-                            var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
-                            Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                            
+                            if (CurrentVersion >= new Version("3.7.15"))
+                            {
+                                var message = NativeMethods.sqlite3_errstr(SQLITE_BUSY);
+                                Assert.Equal(Strings.FormatSqliteNativeError(SQLITE_BUSY, message), ex.Message);
+                            }
                         });
 
                     t1.Start();
@@ -202,6 +210,8 @@ INSERT INTO a VALUES (2);";
                 }
             }
         }
+        
+        private Version CurrentVersion => new Version(NativeMethods.sqlite3_libversion());
 
         private const string FileName = "./concurrency.db";
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using System.IO;
+using Microsoft.AspNet.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.Data.Sqlite
@@ -60,7 +61,8 @@ namespace Microsoft.Data.Sqlite
             Assert.Equal("test.db", connection.DataSource);
         }
 
-        [Fact]
+        [ConditionalFact]
+        [SqliteVersionCondition(Min = "3.7.10")]
         public void DataSource_returns_actual_filename_when_open()
         {
             using (var connection = new SqliteConnection("Data Source=test.db"))

--- a/test/Microsoft.Data.Sqlite.Tests/TestUtilities/SqliteVersionConditionAttribute.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/TestUtilities/SqliteVersionConditionAttribute.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Sqlite.Interop;
+using Microsoft.AspNet.Testing.xunit;
+
+namespace Microsoft.Data.Sqlite
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    internal class SqliteVersionConditionAttribute : Attribute, ITestCondition
+    {
+        private Version _min;
+        private Version _max;
+        private Version _skip;
+        public string Min { get { return _min.ToString(); } set { _min = new Version(value); } }
+        public string Max { get { return _max.ToString(); } set { _max = new Version(value); } }
+        public string Skip { get { return _skip.ToString(); } set { _skip = new Version(value); } }
+
+        private Version Current = new Version(NativeMethods.sqlite3_libversion());
+
+        public bool IsMet
+        {
+            get
+            {
+                if (Current == _skip)
+                {
+                    return false;
+                }
+
+                if (_min == null && _max == null)
+                {
+                    return true;
+                }
+
+                if (_min == null)
+                {
+                    return Current <= _max;
+                }
+
+                if (_max == null)
+                {
+                    return Current >= _min;
+                }
+
+                return Current <= _max && Current >= _min;
+            }
+        }
+
+        private string _skipReason;
+        
+        public string SkipReason
+        {
+            set { _skipReason = value; }
+            get
+            {
+                return _skipReason ??
+                        $"Test only runs for SQLite versions >= { Min ?? "Any"} and <= { Max ?? "Any" }"
+                        + (Skip == null ? "" : "and skipping on " + Skip);
+            }
+        }
+    }
+}


### PR DESCRIPTION
SQLite 3.7.9 is the default library version on Travis Linux agents.
3.7.13 is the default version on aspnet-docker (Fix https://github.com/aspnet/aspnet-docker/issues/85) and Travis OSX agents.

Fallback to older sqlite3 calls when using older versions of sqlite3.

sqlite3_close and sqlite3_errstr do not exist < 3.7.15
sqlite3_db_filename does not exist < 3.7.10

Add internal utilities for working with different sqlite versions and testing.
Add OSX and Mono alpha to test matrix.