### PR TITLE
Fixed mono compiler issues

### DIFF
--- a/src/Microsoft.Data.Sqlite/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteParameter.cs
@@ -269,7 +269,6 @@ namespace Microsoft.Data.Sqlite
 
         private int FindPrefixedParameter(Sqlite3StmtHandle stmt)
         {
-            var count = NativeMethods.sqlite3_bind_parameter_count(stmt);
             var index = 0;
             int nextIndex;
 

--- a/src/Microsoft.Data.Sqlite/project.json
+++ b/src/Microsoft.Data.Sqlite/project.json
@@ -11,7 +11,8 @@
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
       },
       "frameworkAssemblies": {
-        "System.Data": "4.0.0.0"
+        "System.Data": "",
+        "System.Xml": ""
       }
     },
     "dotnet5.4": {


### PR DESCRIPTION
For some strange reason, the mono c# compiler catches more issues than csc. Here are the compiler errors/warnings being fixed in this commit:

```
/Users/dfowler/dev/git/ProjectK/Universe/Microsoft.Data.Sqlite/src/Microsoft.Data.Sqlite/SqliteDataReader.cs(135,25): error CS0012: The type `System.Xml.Serialization.IXmlSerializable' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
```

```
/Users/dfowler/dev/git/ProjectK/Universe/Microsoft.Data.Sqlite/src/Microsoft.Data.Sqlite/SqliteParameter.cs(272,17): error CS0219: Warning as Error: The variable `count' is assigned but its value is never used
```