### PR TITLE
[small] Better handling for in-memory connection strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,4 @@ project.lock.json
 .settings
 *.sublime-*
 *.pfx
-
-# Ignore vagrant - used for cross-platform testing
-.vagrant/
-Vagrantfile
+launchSettings.json

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
@@ -144,25 +144,6 @@ namespace Microsoft.Data.Sqlite.Interop
         [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
         public static extern int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_db_filename(Sqlite3Handle db, IntPtr zDbName);
-
-        public static string sqlite3_db_filename(Sqlite3Handle db, string zDbName)
-        {
-            var ptr = MarshalEx.StringToHGlobalUTF8(zDbName);
-            try
-            {
-                return MarshalEx.PtrToStringUTF8(sqlite3_db_filename(db, ptr));
-            }
-            finally
-            {
-                if (ptr != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(ptr);
-                }
-            }
-        }
-
         [DllImport("sqlite3", EntryPoint = "sqlite3_errmsg", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr sqlite3_errmsg_raw(Sqlite3Handle db);
 

--- a/src/Microsoft.Data.Sqlite/Interop/VersionedMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/VersionedMethods.cs
@@ -19,9 +19,6 @@ namespace Microsoft.Data.Sqlite.Interop
         public static int SqliteClose(IntPtr handle)
            => _strategy.Close(handle);
 
-        public static string SqliteDbFilename(Sqlite3Handle db, string databaseName)
-            => _strategy.DbFilename(db, databaseName);
-
         private static readonly StrategyBase _strategy = GetStrategy(new Version(NativeMethods.sqlite3_libversion()));
 
         private static StrategyBase GetStrategy(Version current)
@@ -34,10 +31,6 @@ namespace Microsoft.Data.Sqlite.Interop
             {
                 return new Strategy3_7_14();
             }
-            if (current >= new Version("3.7.10"))
-            {
-                return new Strategy3_7_10();
-            }
             return new StrategyBase();
         }
 
@@ -47,16 +40,10 @@ namespace Microsoft.Data.Sqlite.Interop
                 => NativeMethods.sqlite3_errstr(rc) + " " + base.ErrorString(rc);
         }
 
-        private class Strategy3_7_14 : Strategy3_7_10
+        private class Strategy3_7_14 : StrategyBase
         {
             public override int Close(IntPtr handle)
                 => NativeMethods.sqlite3_close_v2(handle);
-        }
-
-        private class Strategy3_7_10 : StrategyBase
-        {
-            public override string DbFilename(Sqlite3Handle db, string databaseName)
-                => NativeMethods.sqlite3_db_filename(db, databaseName);
         }
 
         private class StrategyBase
@@ -66,9 +53,6 @@ namespace Microsoft.Data.Sqlite.Interop
                 
             public virtual int Close(IntPtr handle)
                 => NativeMethods.sqlite3_close(handle);
-                
-            public virtual string DbFilename(Sqlite3Handle db, string databaseName)
-                => null;
         }
     }
 }


### PR DESCRIPTION
Improvements to handle in-memory connection strings. 

`SqlConnection.DataSource` returned differencly based on whether the connection is open or not. Instead of relying on sqlite3_db_filename, this API now includes the logic used to adjust for relative paths.