### PR TITLE
Enable using winsqlite3.dll

### DIFF
--- a/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/MarshalEx.cs
@@ -60,7 +60,11 @@ namespace Microsoft.Data.Sqlite.Interop
                 return;
             }
 
-            throw new SqliteException(VersionedMethods.SqliteErrorMessage(rc, db), rc);
+            var message = db == null || db.IsInvalid
+                ? VersionedMethods.GetErrorString(rc)
+                : NativeMethods.sqlite3_errmsg(db);
+
+            throw new SqliteException(Strings.FormatSqliteNativeError(rc, message), rc);
         }
     }
 }

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethods.cs
@@ -1,58 +1,52 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-
-#if NET451
-using Microsoft.Data.Sqlite.Utilities;
-#endif
 
 namespace Microsoft.Data.Sqlite.Interop
 {
-    internal static class NativeMethods
+    internal static partial class NativeMethods
     {
-#if NET451
-        static NativeMethods()
+        private static string _dllName = "sqlite3";
+        private static Lazy<ISqlite3> _sqlite3 = new Lazy<ISqlite3>(() => Load(_dllName));
+
+        public static void SetDllName(string dllName)
         {
-            // NOTE: This is used by AnyCPU applications to load the native library based on the process's
-            //       architecture. It does nothing on DNX and Mono which handle native library loading themselves.
-            var loaded = NativeLibraryLoader.TryLoad("sqlite3");
-            Debug.Assert(loaded, "loaded is false.");
+            if (_sqlite3.IsValueCreated)
+            {
+                throw new InvalidOperationException(Strings.AlreadyLoaded);
+            }
+
+            _dllName = dllName;
         }
-#endif
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel);
+        private static ISqlite3 Sqlite3 => _sqlite3.Value;
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_bind_double(Sqlite3StmtHandle pStmt, int i, double rValue);
+        public static int sqlite3_bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel)
+            => Sqlite3.bind_blob(pStmt, i, zData, nData, xDel);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue);
+        public static int sqlite3_bind_double(Sqlite3StmtHandle pStmt, int i, double rValue)
+            => Sqlite3.bind_double(pStmt, i, rValue);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_bind_null(Sqlite3StmtHandle pStmt, int i);
+        public static int sqlite3_bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue)
+            => Sqlite3.bind_int64(pStmt, i, iValue);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_bind_parameter_count(Sqlite3StmtHandle stmt);
+        public static int sqlite3_bind_null(Sqlite3StmtHandle pStmt, int i)
+            => Sqlite3.bind_null(pStmt, i);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int sqlite3_bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName);
-
-        [DllImport("sqlite3", EntryPoint = "sqlite3_bind_parameter_name", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_bind_parameter_name_raw(Sqlite3StmtHandle stmt, int i);
+        public static int sqlite3_bind_parameter_count(Sqlite3StmtHandle stmt)
+            => Sqlite3.bind_parameter_count(stmt);
 
         public static string sqlite3_bind_parameter_name(Sqlite3StmtHandle stmt, int i)
-            => MarshalEx.PtrToStringUTF8(sqlite3_bind_parameter_name_raw(stmt, i));
+            => MarshalEx.PtrToStringUTF8(Sqlite3.bind_parameter_name(stmt, i));
 
         public static int sqlite3_bind_parameter_index(Sqlite3StmtHandle pStmt, string zName)
         {
             var ptr = MarshalEx.StringToHGlobalUTF8(zName);
             try
             {
-                return sqlite3_bind_parameter_index(pStmt, ptr);
+                return Sqlite3.bind_parameter_index(pStmt, ptr);
             }
             finally
             {
@@ -63,16 +57,13 @@ namespace Microsoft.Data.Sqlite.Interop
             }
         }
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        private static extern int sqlite3_bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel);
-
         public static int sqlite3_bind_text(Sqlite3StmtHandle pStmt, int i, string data, IntPtr xDel)
         {
             int nLen;
             var zData = MarshalEx.StringToHGlobalUTF8(data, out nLen);
             try
             {
-                return sqlite3_bind_text(pStmt, i, zData, nLen, xDel);
+                return Sqlite3.bind_text(pStmt, i, zData, nLen, xDel);
             }
             finally
             {
@@ -83,30 +74,27 @@ namespace Microsoft.Data.Sqlite.Interop
             }
         }
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_busy_timeout(Sqlite3Handle db, int ms);
+        public static int sqlite3_busy_timeout(Sqlite3Handle db, int ms)
+            => Sqlite3.busy_timeout(db, ms);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_changes(Sqlite3Handle db);
+        public static int sqlite3_changes(Sqlite3Handle db)
+            => Sqlite3.changes(db);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_close_v2(IntPtr db);
+        public static int sqlite3_close(IntPtr db)
+            => Sqlite3.close(db);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_close(IntPtr db);
-
-        [DllImport("sqlite3", EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_column_blob_raw(Sqlite3StmtHandle pStmt, int iCol);
+        public static int sqlite3_close_v2(IntPtr db)
+            => Sqlite3.close_v2(db);
 
         public static byte[] sqlite3_column_blob(Sqlite3StmtHandle pStmt, int iCol)
         {
-            var ptr = sqlite3_column_blob_raw(pStmt, iCol);
+            var ptr = Sqlite3.column_blob(pStmt, iCol);
             if (ptr == IntPtr.Zero)
             {
                 return null;
             }
 
-            var bytes = sqlite3_column_bytes(pStmt, iCol);
+            var bytes = Sqlite3.column_bytes(pStmt, iCol);
 
             var result = new byte[bytes];
             Marshal.Copy(ptr, result, 0, bytes);
@@ -114,45 +102,33 @@ namespace Microsoft.Data.Sqlite.Interop
             return result;
         }
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int sqlite3_column_bytes(Sqlite3StmtHandle pStmt, int iCol);
+        public static int sqlite3_column_count(Sqlite3StmtHandle stmt)
+            => Sqlite3.column_count(stmt);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_column_count(Sqlite3StmtHandle stmt);
+        public static string sqlite3_column_decltype(Sqlite3StmtHandle stmt, int iCol)
+            => MarshalEx.PtrToStringUTF8(Sqlite3.column_decltype(stmt, iCol));
 
-        [DllImport("sqlite3", EntryPoint = "sqlite3_column_decltype", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr sqlite3_column_decltype_raw(Sqlite3StmtHandle stmt, int iCol);
+        public static double sqlite3_column_double(Sqlite3StmtHandle stmt, int iCol)
+            => Sqlite3.column_double(stmt, iCol);
 
-        public static string sqlite3_column_decltype(Sqlite3StmtHandle stmt, int iCol) => MarshalEx.PtrToStringUTF8(sqlite3_column_decltype_raw(stmt, iCol));
+        public static long sqlite3_column_int64(Sqlite3StmtHandle stmt, int iCol)
+            => Sqlite3.column_int64(stmt, iCol);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern double sqlite3_column_double(Sqlite3StmtHandle stmt, int iCol);
+        public static string sqlite3_column_name(Sqlite3StmtHandle stmt, int iCol)
+            => MarshalEx.PtrToStringUTF8(Sqlite3.column_name(stmt, iCol));
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern long sqlite3_column_int64(Sqlite3StmtHandle stmt, int iCol);
+        public static string sqlite3_column_text(Sqlite3StmtHandle stmt, int iCol)
+            => MarshalEx.PtrToStringUTF8(Sqlite3.column_text(stmt, iCol));
 
-        [DllImport("sqlite3", EntryPoint = "sqlite3_column_name", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_column_name_raw(Sqlite3StmtHandle stmt, int iCol);
-
-        public static string sqlite3_column_name(Sqlite3StmtHandle stmt, int iCol) => MarshalEx.PtrToStringUTF8(sqlite3_column_name_raw(stmt, iCol));
-
-        [DllImport("sqlite3", EntryPoint = "sqlite3_column_text", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_column_text_raw(Sqlite3StmtHandle stmt, int iCol);
-
-        public static string sqlite3_column_text(Sqlite3StmtHandle stmt, int iCol) => MarshalEx.PtrToStringUTF8(sqlite3_column_text_raw(stmt, iCol));
-
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol);
-
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_db_filename(Sqlite3Handle db, IntPtr zDbName);
+        public static int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol)
+            => Sqlite3.column_type(stmt, iCol);
 
         public static string sqlite3_db_filename(Sqlite3Handle db, string zDbName)
         {
             var ptr = MarshalEx.StringToHGlobalUTF8(zDbName);
             try
             {
-                return MarshalEx.PtrToStringUTF8(sqlite3_db_filename(db, ptr));
+                return MarshalEx.PtrToStringUTF8(Sqlite3.db_filename(db, ptr));
             }
             finally
             {
@@ -163,26 +139,20 @@ namespace Microsoft.Data.Sqlite.Interop
             }
         }
 
-        [DllImport("sqlite3", EntryPoint = "sqlite3_errmsg", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_errmsg_raw(Sqlite3Handle db);
+        public static int sqlite3_enable_load_extension(Sqlite3Handle db, int onoff)
+            => Sqlite3.enable_load_extension(db, onoff);
 
-        public static string sqlite3_errmsg(Sqlite3Handle db) => MarshalEx.PtrToStringUTF8(sqlite3_errmsg_raw(db));
+        public static string sqlite3_errmsg(Sqlite3Handle db)
+            => MarshalEx.PtrToStringUTF8(Sqlite3.errmsg(db));
 
-        [DllImport("sqlite3", EntryPoint = "sqlite3_errstr", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_errstr_raw(int rc);
+        public static string sqlite3_errstr(int rc)
+            => MarshalEx.PtrToStringUTF8(Sqlite3.errstr(rc));
 
-        public static string sqlite3_errstr(int rc) => MarshalEx.PtrToStringUTF8(sqlite3_errstr_raw(rc));
+        public static int sqlite3_finalize(IntPtr pStmt)
+            => Sqlite3.finalize(pStmt);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_finalize(IntPtr pStmt);
-
-        [DllImport("sqlite3", EntryPoint = "sqlite3_libversion", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr sqlite3_libversion_raw();
-
-        public static string sqlite3_libversion() => MarshalEx.PtrToStringUTF8(sqlite3_libversion_raw());
-
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        private static extern int sqlite3_open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs);
+        public static string sqlite3_libversion()
+            => MarshalEx.PtrToStringUTF8(Sqlite3.libversion());
 
         public static int sqlite3_open_v2(string filename, out Sqlite3Handle ppDb, int flags, string vfs)
         {
@@ -190,7 +160,7 @@ namespace Microsoft.Data.Sqlite.Interop
             var zVfs = string.IsNullOrEmpty(vfs) ? IntPtr.Zero : MarshalEx.StringToHGlobalUTF8(vfs);
             try
             {
-                return sqlite3_open_v2(zFilename, out ppDb, flags, zVfs);
+                return Sqlite3.open_v2(zFilename, out ppDb, flags, zVfs);
             }
             finally
             {
@@ -205,19 +175,14 @@ namespace Microsoft.Data.Sqlite.Interop
             }
         }
 
-        // sqlite3.dll converts this to UTF-8 to parse
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int sqlite3_prepare_v2(Sqlite3Handle db, IntPtr zSql, int nByte, out Sqlite3StmtHandle ppStmt, out IntPtr pzTail);
-
         public static int sqlite3_prepare_v2(Sqlite3Handle db, string zSql, out Sqlite3StmtHandle ppStmt, out string pzTail)
         {
             int nByte;
             var zSqlPtr = MarshalEx.StringToHGlobalUTF8(zSql, out nByte);
             try
             {
-                // TODO: Something fancy with indexes?
                 IntPtr pzTailPtr;
-                var rc = sqlite3_prepare_v2(db, zSqlPtr, nByte, out ppStmt, out pzTailPtr);
+                var rc = Sqlite3.prepare_v2(db, zSqlPtr, nByte, out ppStmt, out pzTailPtr);
                 pzTail = MarshalEx.PtrToStringUTF8(pzTailPtr);
 
                 return rc;
@@ -228,13 +193,49 @@ namespace Microsoft.Data.Sqlite.Interop
             }
         }
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_reset(Sqlite3StmtHandle stmt);
+        public static int sqlite3_reset(Sqlite3StmtHandle stmt)
+            => Sqlite3.reset(stmt);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_step(Sqlite3StmtHandle stmt);
+        public static int sqlite3_step(Sqlite3StmtHandle stmt)
+            => Sqlite3.step(stmt);
 
-        [DllImport("sqlite3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int sqlite3_stmt_readonly(Sqlite3StmtHandle pStmt);
+        public static int sqlite3_stmt_readonly(Sqlite3StmtHandle pStmt)
+            => Sqlite3.stmt_readonly(pStmt);
+
+        private interface ISqlite3
+        {
+            int bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel);
+            int bind_double(Sqlite3StmtHandle pStmt, int i, double rValue);
+            int bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue);
+            int bind_null(Sqlite3StmtHandle pStmt, int i);
+            int bind_parameter_count(Sqlite3StmtHandle stmt);
+            int bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName);
+            IntPtr bind_parameter_name(Sqlite3StmtHandle stmt, int i);
+            int bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel);
+            int busy_timeout(Sqlite3Handle db, int ms);
+            int changes(Sqlite3Handle db);
+            int close(IntPtr db);
+            int close_v2(IntPtr db);
+            IntPtr column_blob(Sqlite3StmtHandle pStmt, int iCol);
+            int column_bytes(Sqlite3StmtHandle pStmt, int iCol);
+            int column_count(Sqlite3StmtHandle stmt);
+            IntPtr column_decltype(Sqlite3StmtHandle stmt, int iCol);
+            double column_double(Sqlite3StmtHandle stmt, int iCol);
+            long column_int64(Sqlite3StmtHandle stmt, int iCol);
+            IntPtr column_name(Sqlite3StmtHandle stmt, int iCol);
+            IntPtr column_text(Sqlite3StmtHandle stmt, int iCol);
+            int column_type(Sqlite3StmtHandle stmt, int iCol);
+            IntPtr db_filename(Sqlite3Handle db, IntPtr zDbName);
+            int enable_load_extension(Sqlite3Handle db, int onoff);
+            IntPtr errmsg(Sqlite3Handle db);
+            IntPtr errstr(int rc);
+            int finalize(IntPtr pStmt);
+            IntPtr libversion();
+            int open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs);
+            int prepare_v2(Sqlite3Handle db, IntPtr zSql, int nByte, out Sqlite3StmtHandle ppStmt, out IntPtr pzTail);
+            int reset(Sqlite3StmtHandle stmt);
+            int step(Sqlite3StmtHandle stmt);
+            int stmt_readonly(Sqlite3StmtHandle pStmt);
+        }
     }
 }

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethodsImpl.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethodsImpl.cs
@@ -1,0 +1,441 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+#if NET451
+using Microsoft.Data.Sqlite.Utilities;
+#endif
+
+namespace Microsoft.Data.Sqlite.Interop
+{
+    partial class NativeMethods
+    {
+        private static ISqlite3 Load(string dllName)
+        {
+            switch (dllName)
+            {
+                case "sqlite3":
+#if NET451
+                    // NOTE: This is used by AnyCPU applications to load the native library based on the process's
+                    //       architecture. It does nothing on DNX and Mono which handle native library loading themselves.
+                    var loaded = NativeLibraryLoader.TryLoad("sqlite3");
+                    Debug.Assert(loaded, "loaded is false.");
+#endif
+                    return new Sqlite3_sqlite3();
+
+                case "winsqlite3":
+                    return new Sqlite3_winsqlite3();
+
+                default:
+                    Debug.Fail("Unexpected dllName: " + dllName);
+                    goto case "sqlite3";
+            }
+        }
+
+        private class Sqlite3_sqlite3 : ISqlite3
+        {
+            private const string DllName = "sqlite3";
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel);
+
+            public int bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel)
+                => sqlite3_bind_blob(pStmt, i, zData, nData, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_double(Sqlite3StmtHandle pStmt, int i, double rValue);
+
+            public int bind_double(Sqlite3StmtHandle pStmt, int i, double rValue)
+                => sqlite3_bind_double(pStmt, i, rValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue);
+
+            public int bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue)
+                => sqlite3_bind_int64(pStmt, i, iValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_null(Sqlite3StmtHandle pStmt, int i);
+
+            public int bind_null(Sqlite3StmtHandle pStmt, int i)
+                => sqlite3_bind_null(pStmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_count(Sqlite3StmtHandle stmt);
+
+            public int bind_parameter_count(Sqlite3StmtHandle stmt)
+                => sqlite3_bind_parameter_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName);
+
+            public int bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName)
+                => sqlite3_bind_parameter_index(pStmt, zName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_bind_parameter_name(Sqlite3StmtHandle stmt, int i);
+
+            public IntPtr bind_parameter_name(Sqlite3StmtHandle stmt, int i)
+                => sqlite3_bind_parameter_name(stmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel);
+
+            public int bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel)
+                => sqlite3_bind_text(pStmt, i, zData, n, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_busy_timeout(Sqlite3Handle db, int ms);
+
+            public int busy_timeout(Sqlite3Handle db, int ms)
+                => sqlite3_busy_timeout(db, ms);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_changes(Sqlite3Handle db);
+
+            public int changes(Sqlite3Handle db)
+                => sqlite3_changes(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close(IntPtr db);
+
+            public int close(IntPtr db)
+                => sqlite3_close(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close_v2(IntPtr db);
+
+            public int close_v2(IntPtr db)
+                => sqlite3_close_v2(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_blob(Sqlite3StmtHandle pStmt, int iCol);
+
+            public IntPtr column_blob(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_blob(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_bytes(Sqlite3StmtHandle pStmt, int iCol);
+
+            public int column_bytes(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_bytes(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_count(Sqlite3StmtHandle stmt);
+
+            public int column_count(Sqlite3StmtHandle stmt)
+                => sqlite3_column_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_decltype(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_decltype(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_decltype(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern double sqlite3_column_double(Sqlite3StmtHandle stmt, int iCol);
+
+            public double column_double(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_double(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern long sqlite3_column_int64(Sqlite3StmtHandle stmt, int iCol);
+
+            public long column_int64(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_int64(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_name(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_name(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_name(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_text(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_text(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_text(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol);
+
+            public int column_type(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_type(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_db_filename(Sqlite3Handle db, IntPtr zDbName);
+
+            public IntPtr db_filename(Sqlite3Handle db, IntPtr zDbName)
+                => sqlite3_db_filename(db, zDbName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_enable_load_extension(Sqlite3Handle db, int onoff);
+
+            public int enable_load_extension(Sqlite3Handle db, int onoff)
+                => sqlite3_enable_load_extension(db, onoff);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errmsg(Sqlite3Handle db);
+
+            public IntPtr errmsg(Sqlite3Handle db)
+                => sqlite3_errmsg(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errstr(int rc);
+
+            public IntPtr errstr(int rc)
+                => sqlite3_errstr(rc);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_finalize(IntPtr pStmt);
+
+            public int finalize(IntPtr pStmt)
+                => sqlite3_finalize(pStmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_libversion();
+
+            public IntPtr libversion()
+                => sqlite3_libversion();
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs);
+
+            public int open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs)
+                => sqlite3_open_v2(filename, out ppDb, flags, vfs);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_prepare_v2(
+                Sqlite3Handle db,
+                IntPtr zSql,
+                int nByte,
+                out Sqlite3StmtHandle ppStmt,
+                out IntPtr pzTail);
+
+            public int prepare_v2(Sqlite3Handle db, IntPtr zSql, int nByte, out Sqlite3StmtHandle ppStmt, out IntPtr pzTail)
+                => sqlite3_prepare_v2(db, zSql, nByte, out ppStmt, out pzTail);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_reset(Sqlite3StmtHandle stmt);
+
+            public int reset(Sqlite3StmtHandle stmt)
+                => sqlite3_reset(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_step(Sqlite3StmtHandle stmt);
+
+            public int step(Sqlite3StmtHandle stmt)
+                => sqlite3_step(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_stmt_readonly(Sqlite3StmtHandle pStmt);
+
+            public int stmt_readonly(Sqlite3StmtHandle pStmt)
+                => sqlite3_stmt_readonly(pStmt);
+        }
+        private class Sqlite3_winsqlite3 : ISqlite3
+        {
+            private const string DllName = "winsqlite3";
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel);
+
+            public int bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel)
+                => sqlite3_bind_blob(pStmt, i, zData, nData, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_double(Sqlite3StmtHandle pStmt, int i, double rValue);
+
+            public int bind_double(Sqlite3StmtHandle pStmt, int i, double rValue)
+                => sqlite3_bind_double(pStmt, i, rValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue);
+
+            public int bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue)
+                => sqlite3_bind_int64(pStmt, i, iValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_null(Sqlite3StmtHandle pStmt, int i);
+
+            public int bind_null(Sqlite3StmtHandle pStmt, int i)
+                => sqlite3_bind_null(pStmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_count(Sqlite3StmtHandle stmt);
+
+            public int bind_parameter_count(Sqlite3StmtHandle stmt)
+                => sqlite3_bind_parameter_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName);
+
+            public int bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName)
+                => sqlite3_bind_parameter_index(pStmt, zName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_bind_parameter_name(Sqlite3StmtHandle stmt, int i);
+
+            public IntPtr bind_parameter_name(Sqlite3StmtHandle stmt, int i)
+                => sqlite3_bind_parameter_name(stmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel);
+
+            public int bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel)
+                => sqlite3_bind_text(pStmt, i, zData, n, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_busy_timeout(Sqlite3Handle db, int ms);
+
+            public int busy_timeout(Sqlite3Handle db, int ms)
+                => sqlite3_busy_timeout(db, ms);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_changes(Sqlite3Handle db);
+
+            public int changes(Sqlite3Handle db)
+                => sqlite3_changes(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close(IntPtr db);
+
+            public int close(IntPtr db)
+                => sqlite3_close(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close_v2(IntPtr db);
+
+            public int close_v2(IntPtr db)
+                => sqlite3_close_v2(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_blob(Sqlite3StmtHandle pStmt, int iCol);
+
+            public IntPtr column_blob(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_blob(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_bytes(Sqlite3StmtHandle pStmt, int iCol);
+
+            public int column_bytes(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_bytes(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_count(Sqlite3StmtHandle stmt);
+
+            public int column_count(Sqlite3StmtHandle stmt)
+                => sqlite3_column_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_decltype(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_decltype(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_decltype(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern double sqlite3_column_double(Sqlite3StmtHandle stmt, int iCol);
+
+            public double column_double(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_double(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern long sqlite3_column_int64(Sqlite3StmtHandle stmt, int iCol);
+
+            public long column_int64(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_int64(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_name(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_name(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_name(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_text(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_text(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_text(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol);
+
+            public int column_type(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_type(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_db_filename(Sqlite3Handle db, IntPtr zDbName);
+
+            public IntPtr db_filename(Sqlite3Handle db, IntPtr zDbName)
+                => sqlite3_db_filename(db, zDbName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_enable_load_extension(Sqlite3Handle db, int onoff);
+
+            public int enable_load_extension(Sqlite3Handle db, int onoff)
+                => sqlite3_enable_load_extension(db, onoff);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errmsg(Sqlite3Handle db);
+
+            public IntPtr errmsg(Sqlite3Handle db)
+                => sqlite3_errmsg(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errstr(int rc);
+
+            public IntPtr errstr(int rc)
+                => sqlite3_errstr(rc);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_finalize(IntPtr pStmt);
+
+            public int finalize(IntPtr pStmt)
+                => sqlite3_finalize(pStmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_libversion();
+
+            public IntPtr libversion()
+                => sqlite3_libversion();
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs);
+
+            public int open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs)
+                => sqlite3_open_v2(filename, out ppDb, flags, vfs);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_prepare_v2(
+                Sqlite3Handle db,
+                IntPtr zSql,
+                int nByte,
+                out Sqlite3StmtHandle ppStmt,
+                out IntPtr pzTail);
+
+            public int prepare_v2(Sqlite3Handle db, IntPtr zSql, int nByte, out Sqlite3StmtHandle ppStmt, out IntPtr pzTail)
+                => sqlite3_prepare_v2(db, zSql, nByte, out ppStmt, out pzTail);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_reset(Sqlite3StmtHandle stmt);
+
+            public int reset(Sqlite3StmtHandle stmt)
+                => sqlite3_reset(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_step(Sqlite3StmtHandle stmt);
+
+            public int step(Sqlite3StmtHandle stmt)
+                => sqlite3_step(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_stmt_readonly(Sqlite3StmtHandle pStmt);
+
+            public int stmt_readonly(Sqlite3StmtHandle pStmt)
+                => sqlite3_stmt_readonly(pStmt);
+        }
+    }
+}

--- a/src/Microsoft.Data.Sqlite/Interop/NativeMethodsImpl.tt
+++ b/src/Microsoft.Data.Sqlite/Interop/NativeMethodsImpl.tt
@@ -1,0 +1,265 @@
+﻿<#
+    var dllNames = new[]
+    {
+        "sqlite3",
+        "winsqlite3"
+    };
+#>
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+#if NET451
+using Microsoft.Data.Sqlite.Utilities;
+#endif
+
+namespace Microsoft.Data.Sqlite.Interop
+{
+    partial class NativeMethods
+    {
+        private static ISqlite3 Load(string dllName)
+        {
+            switch (dllName)
+            {
+<#
+    foreach (var dllName in dllNames)
+    {
+#>
+                case "<#= dllName #>":
+<#
+    if (dllName == "sqlite3")
+    {
+#>
+#if NET451
+                    // NOTE: This is used by AnyCPU applications to load the native library based on the process's
+                    //       architecture. It does nothing on DNX and Mono which handle native library loading themselves.
+                    var loaded = NativeLibraryLoader.TryLoad("sqlite3");
+                    Debug.Assert(loaded, "loaded is false.");
+#endif
+<#
+    }
+#>
+                    return new Sqlite3_<#= dllName #>();
+
+<#
+    }
+#>
+                default:
+                    Debug.Fail("Unexpected dllName: " + dllName);
+                    goto case "sqlite3";
+            }
+        }
+
+<#
+    foreach (var dllName in dllNames)
+    {
+#>
+        private class Sqlite3_<#= dllName #> : ISqlite3
+        {
+            private const string DllName = "<#= dllName #>";
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel);
+
+            public int bind_blob(Sqlite3StmtHandle pStmt, int i, byte[] zData, int nData, IntPtr xDel)
+                => sqlite3_bind_blob(pStmt, i, zData, nData, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_double(Sqlite3StmtHandle pStmt, int i, double rValue);
+
+            public int bind_double(Sqlite3StmtHandle pStmt, int i, double rValue)
+                => sqlite3_bind_double(pStmt, i, rValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue);
+
+            public int bind_int64(Sqlite3StmtHandle pStmt, int i, long iValue)
+                => sqlite3_bind_int64(pStmt, i, iValue);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_null(Sqlite3StmtHandle pStmt, int i);
+
+            public int bind_null(Sqlite3StmtHandle pStmt, int i)
+                => sqlite3_bind_null(pStmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_count(Sqlite3StmtHandle stmt);
+
+            public int bind_parameter_count(Sqlite3StmtHandle stmt)
+                => sqlite3_bind_parameter_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName);
+
+            public int bind_parameter_index(Sqlite3StmtHandle pStmt, IntPtr zName)
+                => sqlite3_bind_parameter_index(pStmt, zName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_bind_parameter_name(Sqlite3StmtHandle stmt, int i);
+
+            public IntPtr bind_parameter_name(Sqlite3StmtHandle stmt, int i)
+                => sqlite3_bind_parameter_name(stmt, i);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel);
+
+            public int bind_text(Sqlite3StmtHandle pStmt, int i, IntPtr zData, int n, IntPtr xDel)
+                => sqlite3_bind_text(pStmt, i, zData, n, xDel);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_busy_timeout(Sqlite3Handle db, int ms);
+
+            public int busy_timeout(Sqlite3Handle db, int ms)
+                => sqlite3_busy_timeout(db, ms);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_changes(Sqlite3Handle db);
+
+            public int changes(Sqlite3Handle db)
+                => sqlite3_changes(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close(IntPtr db);
+
+            public int close(IntPtr db)
+                => sqlite3_close(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_close_v2(IntPtr db);
+
+            public int close_v2(IntPtr db)
+                => sqlite3_close_v2(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_blob(Sqlite3StmtHandle pStmt, int iCol);
+
+            public IntPtr column_blob(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_blob(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_bytes(Sqlite3StmtHandle pStmt, int iCol);
+
+            public int column_bytes(Sqlite3StmtHandle pStmt, int iCol)
+                => sqlite3_column_bytes(pStmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_count(Sqlite3StmtHandle stmt);
+
+            public int column_count(Sqlite3StmtHandle stmt)
+                => sqlite3_column_count(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_decltype(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_decltype(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_decltype(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern double sqlite3_column_double(Sqlite3StmtHandle stmt, int iCol);
+
+            public double column_double(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_double(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern long sqlite3_column_int64(Sqlite3StmtHandle stmt, int iCol);
+
+            public long column_int64(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_int64(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_name(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_name(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_name(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_column_text(Sqlite3StmtHandle stmt, int iCol);
+
+            public IntPtr column_text(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_text(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_column_type(Sqlite3StmtHandle stmt, int iCol);
+
+            public int column_type(Sqlite3StmtHandle stmt, int iCol)
+                => sqlite3_column_type(stmt, iCol);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_db_filename(Sqlite3Handle db, IntPtr zDbName);
+
+            public IntPtr db_filename(Sqlite3Handle db, IntPtr zDbName)
+                => sqlite3_db_filename(db, zDbName);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_enable_load_extension(Sqlite3Handle db, int onoff);
+
+            public int enable_load_extension(Sqlite3Handle db, int onoff)
+                => sqlite3_enable_load_extension(db, onoff);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errmsg(Sqlite3Handle db);
+
+            public IntPtr errmsg(Sqlite3Handle db)
+                => sqlite3_errmsg(db);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_errstr(int rc);
+
+            public IntPtr errstr(int rc)
+                => sqlite3_errstr(rc);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_finalize(IntPtr pStmt);
+
+            public int finalize(IntPtr pStmt)
+                => sqlite3_finalize(pStmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr sqlite3_libversion();
+
+            public IntPtr libversion()
+                => sqlite3_libversion();
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs);
+
+            public int open_v2(IntPtr filename, out Sqlite3Handle ppDb, int flags, IntPtr vfs)
+                => sqlite3_open_v2(filename, out ppDb, flags, vfs);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_prepare_v2(
+                Sqlite3Handle db,
+                IntPtr zSql,
+                int nByte,
+                out Sqlite3StmtHandle ppStmt,
+                out IntPtr pzTail);
+
+            public int prepare_v2(Sqlite3Handle db, IntPtr zSql, int nByte, out Sqlite3StmtHandle ppStmt, out IntPtr pzTail)
+                => sqlite3_prepare_v2(db, zSql, nByte, out ppStmt, out pzTail);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_reset(Sqlite3StmtHandle stmt);
+
+            public int reset(Sqlite3StmtHandle stmt)
+                => sqlite3_reset(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_step(Sqlite3StmtHandle stmt);
+
+            public int step(Sqlite3StmtHandle stmt)
+                => sqlite3_step(stmt);
+
+            [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            private static extern int sqlite3_stmt_readonly(Sqlite3StmtHandle pStmt);
+
+            public int stmt_readonly(Sqlite3StmtHandle pStmt)
+                => sqlite3_stmt_readonly(pStmt);
+        }
+<#
+    }
+#>
+    }
+}

--- a/src/Microsoft.Data.Sqlite/Interop/Sqlite3Handle.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Sqlite3Handle.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Sqlite.Interop
 
         protected override bool ReleaseHandle()
         {
-            var rc = VersionedMethods.SqliteClose(handle);
+            var rc = VersionedMethods.Close(handle);
             handle = IntPtr.Zero;
 
             return rc == Constants.SQLITE_OK;

--- a/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.xproj
+++ b/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.xproj
@@ -17,5 +17,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Sqlite/Properties/Strings.Designer.cs
@@ -394,6 +394,22 @@ namespace Microsoft.Data.Sqlite
             return string.Format(CultureInfo.CurrentCulture, GetString("AmbiguousParameterName", "parameterName"), parameterName);
         }
 
+        /// <summary>
+        /// The SQLite library is already loaded. UseWinSqlite3 must be called before using SQLite.
+        /// </summary>
+        internal static string AlreadyLoaded
+        {
+            get { return GetString("AlreadyLoaded"); }
+        }
+
+        /// <summary>
+        /// The SQLite library is already loaded. UseWinSqlite3 must be called before using SQLite.
+        /// </summary>
+        internal static string FormatAlreadyLoaded()
+        {
+            return GetString("AlreadyLoaded");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Sqlite/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteConnection.cs
@@ -61,10 +61,19 @@ namespace Microsoft.Data.Sqlite
 
         public override string Database => MainDatabaseName;
 
-        public override string DataSource =>
-            State == ConnectionState.Open
-                ? VersionedMethods.SqliteDbFilename(_db, MainDatabaseName) ?? ConnectionStringBuilder.DataSource
-                : ConnectionStringBuilder.DataSource;
+        public override string DataSource
+        {
+            get
+            {
+                string dataSource = null;
+                if (State == ConnectionState.Open)
+                {
+                    dataSource = VersionedMethods.GetFilename(_db, MainDatabaseName);
+                }
+
+                return dataSource ?? ConnectionStringBuilder.DataSource;
+            }
+        }
 
         /// <summary>
         /// Corresponds to the version of the SQLite library used by the connection.

--- a/src/Microsoft.Data.Sqlite/SqliteEngine.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteEngine.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Sqlite.Interop;
+
+namespace Microsoft.Data.Sqlite
+{
+    public static class SqliteEngine
+    {
+        public static void UseWinSqlite3()
+            => NativeMethods.SetDllName("winsqlite3");
+    }
+}

--- a/src/Microsoft.Data.Sqlite/Strings.resx
+++ b/src/Microsoft.Data.Sqlite/Strings.resx
@@ -189,4 +189,7 @@
   <data name="AmbiguousParameterName" xml:space="preserve">
     <value>Cannot bind the value for parameter '{parameterName}' because multiple matching parameters were found in the command text. Specify the parameter name with the symbol prefix, e.g. '@{parameterName}'.</value>
   </data>
+  <data name="AlreadyLoaded" xml:space="preserve">
+    <value>The SQLite library is already loaded. UseWinSqlite3 must be called before using SQLite.</value>
+  </data>
 </root>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteEngineTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteEngineTest.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Data.Sqlite
+{
+    public class SqliteEngineTest
+    {
+        [Fact]
+        public void UseWinSqlite3_throws_when_loaded()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => SqliteEngine.UseWinSqlite3());
+
+            Assert.Equal(Strings.AlreadyLoaded, ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
To use, call `SqliteEngine.UseWinSqlite3()` before using SQLite.

Fixes #179 