### PR TITLE
Use Declared Table Types in Data Reader with sqlite3_column_decltype

### DIFF
--- a/src/Microsoft.Data.Sqlite/SqliteConvert.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteConvert.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Sqlite
+{
+    public class SqliteConvert
+    {
+        static IDictionary<string, DbType> typeNameToDbTypeMapping = new Dictionary<string, DbType>(StringComparer.OrdinalIgnoreCase)
+        {
+            {"BIGINT",            DbType.Int64 },
+            {"BIGUINT",           DbType.UInt64 },
+            {"BINARY",            DbType.Binary },
+            {"BIT",               DbType.Boolean},
+            {"BLOB",              DbType.Binary},
+            {"BOOL",              DbType.Boolean},
+            {"BOOLEAN",           DbType.Boolean},
+            {"CHAR",              DbType.AnsiStringFixedLength},
+            {"CLOB",              DbType.String},
+            {"COUNTER",           DbType.Int64},
+            {"CURRENCY",          DbType.Decimal},
+            {"DATE",              DbType.DateTime},
+            {"DATETIME",          DbType.DateTime},
+            {"DECIMAL",           DbType.Decimal},
+            {"DOUBLE",            DbType.Double},
+            {"FLOAT",             DbType.Double},
+            {"GENERAL",           DbType.Binary},
+            {"GUID",              DbType.Guid},
+            {"IDENTITY",          DbType.Int64},
+            {"IMAGE",             DbType.Binary},
+            {"INT",               DbType.Int32},
+            {"INT8",              DbType.SByte},
+            {"INT16",             DbType.Int16},
+            {"INT32",             DbType.Int32},
+            {"INT64",             DbType.Int64},
+            {"INTEGER",           DbType.Int64},
+            {"INTEGER8",          DbType.SByte},
+            {"INTEGER16",         DbType.Int16},
+            {"INTEGER32",         DbType.Int32},
+            {"INTEGER64",         DbType.Int64},
+            {"LOGICAL",           DbType.Boolean},
+            {"LONG",              DbType.Int64},
+            {"LONGCHAR",          DbType.String},
+            {"LONGTEXT",          DbType.String},
+            {"LONGVARCHAR",       DbType.String},
+            {"MEMO",              DbType.String},
+            {"MONEY",             DbType.Decimal},
+            {"NCHAR",             DbType.StringFixedLength},
+            {"NOTE",              DbType.String},
+            {"NTEXT",             DbType.String},
+            {"NUMBER",            DbType.Decimal},
+            {"NUMERIC",           DbType.Decimal},
+            {"NVARCHAR",          DbType.String},
+            {"OLEOBJECT",         DbType.Binary},
+            {"RAW",               DbType.Binary},
+            {"REAL",              DbType.Double},
+            {"SINGLE",            DbType.Single},
+            {"SMALLDATE",         DbType.DateTime},
+            {"SMALLINT",          DbType.Int16},
+            {"SMALLUINT",         DbType.UInt16},
+            {"STRING",            DbType.String},
+            {"TEXT",              DbType.String},
+            {"TIME",              DbType.DateTime},
+            {"TIMESTAMP",         DbType.DateTime},
+            {"TINYINT",           DbType.Byte},
+            {"TINYSINT",          DbType.SByte},
+            {"UINT",              DbType.UInt32},
+            {"UINT8",             DbType.Byte},
+            {"UINT16",            DbType.UInt16},
+            {"UINT32",            DbType.UInt32},
+            {"UINT64",            DbType.UInt64},
+            {"ULONG",             DbType.UInt64},
+            {"UNIQUEIDENTIFIER",  DbType.Guid},
+            {"UNSIGNEDINTEGER",   DbType.UInt64},
+            {"UNSIGNEDINTEGER8",  DbType.Byte},
+            {"UNSIGNEDINTEGER16", DbType.UInt16},
+            {"UNSIGNEDINTEGER32", DbType.UInt32},
+            {"UNSIGNEDINTEGER64", DbType.UInt64},
+            {"VARBINARY",         DbType.Binary},
+            {"VARCHAR",           DbType.AnsiString},
+            {"VARCHAR2",          DbType.AnsiString},
+            {"YESNO",             DbType.Boolean},
+        };
+
+        static IDictionary<DbType, Type> dbTypeToTypeMapping = new Dictionary<DbType, Type>
+        {
+            {DbType.AnsiString, typeof(string) },
+            {DbType.Binary,     typeof(byte[]) },
+            {DbType.Byte,       typeof(byte) },
+            {DbType.Boolean,    typeof(bool) },
+            //{DbType.Currency
+            //{DbType.Date
+            {DbType.DateTime,   typeof(DateTime) },
+            {DbType.Decimal,    typeof(decimal) },
+            {DbType.Double,     typeof(double) },
+            {DbType.Guid,       typeof(Guid) },
+            {DbType.Int16,      typeof(short) },
+            {DbType.Int32,      typeof(int) },
+            {DbType.Int64,      typeof(long) },
+            //{DbType.Object
+            {DbType.SByte,      typeof(sbyte) },
+            {DbType.Single,     typeof(Single) },
+            {DbType.String,     typeof(string) },
+            //{DbType.Time
+            {DbType.UInt16,     typeof(ushort) },
+            {DbType.UInt32,     typeof(uint) },
+            {DbType.UInt64,     typeof(ulong) },
+            //{DbType.VarNumeric
+            {DbType.AnsiStringFixedLength, typeof(string) },
+            {DbType.StringFixedLength,     typeof(string) },
+            //{DbType.Xml
+            {DbType.DateTime2,      typeof(DateTime) },
+            {DbType.DateTimeOffset, typeof(DateTimeOffset) },
+        };
+
+        public static Type TypeNameToType(string typeName)
+        {
+            DbType dbType;
+            if (!typeNameToDbTypeMapping.TryGetValue(typeName, out dbType))
+            {
+                var index = typeName.IndexOf('(');
+                if (index > 0)
+                {
+                    var newTypeName = typeName.Substring(0, index);
+                    if (!typeNameToDbTypeMapping.TryGetValue(newTypeName, out dbType))
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            Type returnType;
+            if (!dbTypeToTypeMapping.TryGetValue(dbType, out returnType))
+            {
+                return null;
+            }
+            return returnType;
+        }
+    }
+}

--- a/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteDataReader.cs
@@ -245,6 +245,15 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Strings.FormatDataReaderClosed("GetFieldType"));
             }
 
+            var typeName = NativeMethods.sqlite3_column_decltype(_stmt, ordinal);
+            if (typeName != null)
+            {
+                var returnType = SqliteConvert.TypeNameToType(typeName);
+                if (returnType != null)
+                {
+                    return returnType;
+                }
+            }
             var sqliteType = GetSqliteType(ordinal);
             switch (sqliteType)
             {
@@ -350,29 +359,34 @@ namespace Microsoft.Data.Sqlite
         public override T GetFieldValue<T>(int ordinal)
         {
             var type = typeof(T).UnwrapNullableType().UnwrapEnumType();
+            return (T)GetFieldValue(type, ordinal);
+        }
+
+        public object GetFieldValue(Type type, int ordinal)
+        {
             if (type == typeof(bool))
             {
-                return (T)(object)GetBoolean(ordinal);
+                return (object)GetBoolean(ordinal);
             }
             if (type == typeof(byte))
             {
-                return (T)(object)GetByte(ordinal);
+                return (object)GetByte(ordinal);
             }
             if (type == typeof(byte[]))
             {
-                return (T)(object)GetBlob(ordinal);
+                return (object)GetBlob(ordinal);
             }
             if (type == typeof(char))
             {
-                return (T)(object)GetChar(ordinal);
+                return (object)GetChar(ordinal);
             }
             if (type == typeof(DateTime))
             {
-                return (T)(object)GetDateTime(ordinal);
+                return (object)GetDateTime(ordinal);
             }
             if (type == typeof(DateTimeOffset))
             {
-                return (T)(object)DateTimeOffset.Parse(GetString(ordinal));
+                return (object)DateTimeOffset.Parse(GetString(ordinal));
             }
             if (type == typeof(DBNull))
             {
@@ -381,62 +395,62 @@ namespace Microsoft.Data.Sqlite
                     throw new InvalidOperationException(Strings.NoData);
                 }
 
-                return (T)(object)DBNull.Value;
+                return (object)DBNull.Value;
             }
             if (type == typeof(decimal))
             {
-                return (T)(object)GetDecimal(ordinal);
+                return (object)GetDecimal(ordinal);
             }
             if (type == typeof(double))
             {
-                return (T)(object)GetDouble(ordinal);
+                return (object)GetDouble(ordinal);
             }
             if (type == typeof(float))
             {
-                return (T)(object)GetFloat(ordinal);
+                return (object)GetFloat(ordinal);
             }
             if (type == typeof(Guid))
             {
-                return (T)(object)GetGuid(ordinal);
+                return (object)GetGuid(ordinal);
             }
             if (type == typeof(int))
             {
-                return (T)(object)GetInt32(ordinal);
+                return (object)GetInt32(ordinal);
             }
             if (type == typeof(long))
             {
-                return (T)(object)GetInt64(ordinal);
+                return (object)GetInt64(ordinal);
             }
             if (type == typeof(sbyte))
             {
-                return (T)(object)((sbyte)GetInt64(ordinal));
+                return (object)((sbyte)GetInt64(ordinal));
             }
             if (type == typeof(short))
             {
-                return (T)(object)GetInt16(ordinal);
+                return (object)GetInt16(ordinal);
             }
             if (type == typeof(string))
             {
-                return (T)(object)GetString(ordinal);
+                return (object)GetString(ordinal);
             }
             if (type == typeof(TimeSpan))
             {
-                return (T)(object)TimeSpan.Parse(GetString(ordinal));
+                return (object)TimeSpan.Parse(GetString(ordinal));
             }
             if (type == typeof(uint))
             {
-                return (T)(object)((uint)GetInt64(ordinal));
+                return (object)((uint)GetInt64(ordinal));
             }
             if (type == typeof(ulong))
             {
-                return (T)(object)((ulong)GetInt64(ordinal));
+                return (object)((ulong)GetInt64(ordinal));
             }
             if (type == typeof(ushort))
             {
-                return (T)(object)((ushort)GetInt64(ordinal));
+                return (object)((ushort)GetInt64(ordinal));
             }
-
-            return base.GetFieldValue<T>(ordinal);
+            throw new ArgumentException();
+            //return base.GetFieldValue<T>(ordinal);
         }
 
         public override object GetValue(int ordinal)
@@ -445,8 +459,23 @@ namespace Microsoft.Data.Sqlite
             {
                 throw new InvalidOperationException(Strings.FormatDataReaderClosed("GetValue"));
             }
-
             var sqliteType = GetSqliteType(ordinal);
+            if (sqliteType == SQLITE_NULL)
+            {
+                if (!_stepped || _done)
+                {
+                    throw new InvalidOperationException(Strings.NoData);
+                }
+
+                return DBNull.Value;
+            }
+
+            var returnType = GetFieldType(ordinal);
+            if (returnType != null)
+            {
+                return GetFieldValue(returnType, ordinal);
+            }
+            
             switch (sqliteType)
             {
                 case SQLITE_INTEGER:
@@ -460,14 +489,6 @@ namespace Microsoft.Data.Sqlite
 
                 case SQLITE_BLOB:
                     return GetBlob(ordinal);
-
-                case SQLITE_NULL:
-                    if (!_stepped || _done)
-                    {
-                        throw new InvalidOperationException(Strings.NoData);
-                    }
-
-                    return DBNull.Value;
 
                 default:
                     Debug.Fail("Unexpected column type: " + sqliteType);

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -329,6 +329,28 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+        [Theory]
+        [InlineData("nvarchar(10)", typeof(string))]
+        [InlineData("NVARCHAR(10)", typeof(string))]
+        [InlineData("decimal(5,2)", typeof(decimal))]
+        [InlineData("numeric(5,2)", typeof(decimal))]
+        [InlineData("Integer8", typeof(sbyte))]
+        [InlineData("uniqueidentifier", typeof(Guid))]
+        [InlineData("UnknownType", typeof(int))]
+        public void GetFieldTypeFromTable_works(string columnType, Type expected)
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                connection.ExecuteNonQuery($"CREATE TABLE T1 (A1 {columnType});");
+                using (var reader = connection.ExecuteReader("SELECT A1 FROM T1;"))
+                {
+                    Assert.Equal(expected, reader.GetFieldType(0));
+                }
+            }
+        }
+
         [Fact]
         public void GetFieldType_throws_when_ordinal_out_of_range()
         {
@@ -504,6 +526,32 @@ namespace Microsoft.Data.Sqlite
 
                     Assert.True(hasData);
                     Assert.Equal(expected, reader.GetValue(0));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("bool", "1", true, typeof(bool))]
+        [InlineData("nvarchar", "'abcdef'", "abcdef", typeof(string))]
+        [InlineData("INT16", "35", (short)35, typeof(short))]
+        [InlineData("CURRENCY", "34.78", 34.78, typeof(decimal))]
+        [InlineData("UnknownType", "35", (long)35, typeof(long))]
+        [InlineData("DateTime", "'2015-03-05'", "2015-03-05 00:00:00", typeof(DateTime))]
+        [InlineData("Single", "35", (Single)35, typeof(Single))]
+        public void GetValue_FromTable_works(string columnType, string data, object expected, Type expectedType)
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery($"CREATE TABLE T1 (A1 {columnType});");
+                connection.ExecuteNonQuery($"INSERT INTO T1 VALUES ({data});");
+                using (var reader = connection.ExecuteReader("SELECT A1 FROM T1"))
+                {
+                    var hasData = reader.Read();
+
+                    Assert.True(hasData);
+                    var converted = Convert.ChangeType(expected, expectedType);
+                    Assert.Equal(converted, reader.GetValue(0));
                 }
             }
         }


### PR DESCRIPTION
For GetFieldType and GetFieldValue, use the column type from
sqlite3_column_decltype to determine the .NET type to use / convert.

This is to resolve issue #204. I want to point out the last line in GetFieldValue. I have changed it to throw an Exception if the type is not handled, which is a change from "base.GetFieldValue<T>(ordinal)".