### PR TITLE
Swapped IsDNX and IsMono to fix running Mono Mobile(Xamarin.Android/Xamarin.iOS)

### DIFF
--- a/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
+++ b/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
@@ -69,7 +69,9 @@ namespace Microsoft.Data.Sqlite.Utilities
             {
                 throw new ArgumentNullException(nameof(dllName));
             }
-            if (IsDNX() || IsMono())
+            // IsMono must be called before IsDNX, because IsDNX is using System.Runtime.Versioning.FrameworkName
+            // type which is missing on Mono Mobile and throws exception instead of returning false
+            if (IsMono() || IsDNX())
             {
                 return true;
             }


### PR DESCRIPTION
Crash happens when IsDNX method is loaded because it tries to load System.Runtime.Versioning.FrameworkName type which is not present on Mono Mobile. If IsMono is called first IsDNX is never called, hence no crash.