### PR TITLE
Removed statically referencing FrameworkName which is missing in Mono Mobile.

### DIFF
--- a/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
+++ b/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
@@ -93,9 +93,10 @@ namespace Microsoft.Data.Sqlite.Utilities
 
                 var defaultPlatformServices = platformServices.GetProperty("Default").GetValue(null);
                 var application = defaultPlatformServices.GetType().GetProperty("Application").GetValue(defaultPlatformServices);
-                var runtimeFramework = (FrameworkName)application.GetType().GetProperty("RuntimeFramework").GetValue(application);
+                var runtimeFramework = application.GetType().GetProperty("RuntimeFramework").GetValue(application);
+                var runtimeFrameworkIdentifier = (string)runtimeFramework.GetType().GetProperty("Identifier").GetValue(runtimeFramework);
 
-                return runtimeFramework.Identifier == "DNX";
+                return runtimeFrameworkIdentifier == "DNX";
             }
             catch (Exception)
             {


### PR DESCRIPTION
With this change if runtime is missing System.Runtime.Versioning.FrameworkName it doesn't crash during method loading.