### PR TITLE
Add CommandBehavior.SingleResult and CommandBehavior.SingleRow to ignored behaviors

### DIFF
--- a/src/Microsoft.Data.Sqlite/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteCommand.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data.Sqlite
 
         public new virtual SqliteDataReader ExecuteReader(CommandBehavior behavior)
         {
-            if ((behavior & ~(CommandBehavior.Default | CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.CloseConnection)) != 0)
+            if ((behavior & ~(CommandBehavior.Default | CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.SingleRow | CommandBehavior.CloseConnection)) != 0)
             {
                 throw new ArgumentException(Strings.FormatInvalidCommandBehavior(behavior));
             }

--- a/src/Microsoft.Data.Sqlite/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite/SqliteCommand.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data.Sqlite
 
         public new virtual SqliteDataReader ExecuteReader(CommandBehavior behavior)
         {
-            if ((behavior & ~(CommandBehavior.Default | CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection)) != 0)
+            if ((behavior & ~(CommandBehavior.Default | CommandBehavior.SequentialAccess | CommandBehavior.SingleResult | CommandBehavior.CloseConnection)) != 0)
             {
                 throw new ArgumentException(Strings.FormatInvalidCommandBehavior(behavior));
             }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -493,6 +493,23 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void ExecuteReader_supports_SingleRow()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = "SELECT 0;";
+                connection.Open();
+
+                using (var reader = command.ExecuteReader(CommandBehavior.SingleRow))
+                {
+                    var hasResult = reader.NextResult();
+                    Assert.False(hasResult);
+                }
+            }
+        }
+
+        [Fact]
         public void ExecuteReader_supports_CloseConnection()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
@@ -513,7 +530,6 @@ namespace Microsoft.Data.Sqlite
         [Theory]
         [InlineData(CommandBehavior.KeyInfo)]
         [InlineData(CommandBehavior.SchemaOnly)]
-        [InlineData(CommandBehavior.SingleRow)]
         public void ExecuteReader_throws_for_unsupported_(CommandBehavior behavior)
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -474,6 +474,23 @@ namespace Microsoft.Data.Sqlite
                 }
             }
         }
+        
+        [Fact]
+        public void ExecuteReader_supports_SingleResult()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = "SELECT 0;";
+                connection.Open();
+
+                using (var reader = command.ExecuteReader(CommandBehavior.SingleResult))
+                {
+                    var hasResult = reader.NextResult();
+                    Assert.False(hasResult);
+                }
+            }
+        }
 
         [Fact]
         public void ExecuteReader_supports_CloseConnection()
@@ -496,7 +513,6 @@ namespace Microsoft.Data.Sqlite
         [Theory]
         [InlineData(CommandBehavior.KeyInfo)]
         [InlineData(CommandBehavior.SchemaOnly)]
-        [InlineData(CommandBehavior.SingleResult)]
         [InlineData(CommandBehavior.SingleRow)]
         public void ExecuteReader_throws_for_unsupported_(CommandBehavior behavior)
         {


### PR DESCRIPTION
This adds `CommandBehavior.SingleResult` and `CommandBehavior.SingleRow` to the ignored "list", addressing #220