### PR TITLE
Fix for SQLITE_BUSY errors throw before command timeout expired

### DIFF
--- a/src/Microsoft.Data.Sqlite/Interop/Constants.cs
+++ b/src/Microsoft.Data.Sqlite/Interop/Constants.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Data.Sqlite.Interop
         public const int SQLITE_OPEN_SHAREDCACHE = 0x00020000;
         public const int SQLITE_OPEN_PRIVATECACHE = 0x00040000;
 
+        public const int SQLITE_BUSY = 5;
         public const int SQLITE_LOCKED = 6;
 
         public static readonly IntPtr SQLITE_TRANSIENT = new IntPtr(-1);

--- a/test/Microsoft.Data.Sqlite.Tests/TestUtilities/Constants.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/TestUtilities/Constants.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Data.Sqlite.TestUtilities
     internal static class Constants
     {
         public const int SQLITE_ERROR = 1;
-        public const int SQLITE_BUSY = 5;
         public const int SQLITE_READONLY = 8;
         public const int SQLITE_CANTOPEN = 14;
     }


### PR DESCRIPTION
Can occur in multi-threaded context. This fixes failing concurrency tests that started failing on OSX and Linux.

Possibly the cause of #222

cc @bricelam 