### PR TITLE
Disable OSX on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.suo
 *.user
 /.nuget/
+/.vscode/
+/.dotnet/
 /.vs/
 /artifacts/
 /packages/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,15 @@ addons:
     - libssl-dev
     - libunwind8
     - zlib1g
-env:
-  - KOREBUILD_TEST_DNXCORE=true KOREBUILD_DNU_RESTORE_CORECLR=true MONO_THREADS_PER_CPU=2000 MONO_MANAGED_WATCHER=disabled
 mono:
   - 4.0.5
 os:
   - linux
-  - osx
+# TODO re-enable when dotnet supports OSX 10.9 or travis upgrades its agents
+#  - osx
+# before_install:
+#  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install icu4c; fi
 before_script:
   - sqlite3 -version
-before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install icu4c; fi
 script:
   - ./build.sh --quiet verify


### PR DESCRIPTION
dotnet requires OSX >= 10.10
Travis agents are OSX 10.9.5
