### PR TITLE
Fixed 'sqlite3.dll not found' error for NET451 build when used in ASP.NET apps (#278)

### DIFF
--- a/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
+++ b/src/Microsoft.Data.Sqlite/Utilities/NativeLibraryLoader.cs
@@ -50,7 +50,11 @@ namespace Microsoft.Data.Sqlite.Utilities
             }
 
             var dllPath = Path.Combine(applicationBase, GetArchitecture(), dllName);
-
+			
+			if (!File.Exists(dllPath)) {
+				dllPath = Path.Combine(applicationBase, "bin", GetArchitecture(), dllName);
+			}
+			
             if (!File.Exists(dllPath))
             {
                 return false;


### PR DESCRIPTION
I also faced with issue when Microsoft.Data.Sqlite cannot load sqlite3.dll (.NET 4.5.1 build) when used in ASP.NET application. 

This happens because nuget package 'SQLite.Native' correctly places native dll to x86 / x64 folders, but for ASP.NET apps they are placed in the 'bin' folder, and NativeLibraryLoader.TryLoad don't handle that correctly (I've fixed that).