### PR TITLE
Increase .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: csharp
 sudo: required
 dist: trusty
-os:
-  - linux
-  - osx
-osx_image: xcode7.1
-mono:
-  - 4.2.2
 addons:
   apt:
     packages:
@@ -16,6 +10,16 @@ addons:
     - libssl-dev
     - libunwind8
     - zlib1g
+env:
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+mono:
+  - 4.0.5
+os:
+  - linux
+  - osx
+osx_image: xcode7.1
 branches:
   only:
     - master


### PR DESCRIPTION
- aspnet/Universe#349
- minimize `dotnet` setup time; no need for caching
- use Mono 4.0.5 for consistency; 4.2.2 not required since Mono tests aren't run