### PR TITLE
:arrow_up: SQLite to 3.12.3

### DIFF
--- a/src/Microsoft.Data.Sqlite/project.json
+++ b/src/Microsoft.Data.Sqlite/project.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.1-*",
-    "SQLite": "3.12.2",
+    "SQLite": "3.12.3",
     "StyleCop.Analyzers": {
       "version": "1.0.0",
       "type": "build"


### PR DESCRIPTION
Because of the impending doom of PJ. 3.12.3 includes a fix for https://github.com/natemcmaster/libsqlite3-package/issues/8, which is that 3.12.2 uses the existence of a file named "project.json" to determine if it is in nuget3 or not...which is not longer the right way to detect this.

cc @bricelam 