### PR TITLE
Fix sqlite3_stmt leak

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -175,11 +175,6 @@ namespace Microsoft.Data.Sqlite
         /// </param>
         protected override void Dispose(bool disposing)
         {
-            if (!disposing)
-            {
-                return;
-            }
-
             if (_stmt != null)
             {
                 _stmt.Dispose();
@@ -189,6 +184,11 @@ namespace Microsoft.Data.Sqlite
             while (_stmtQueue.Count != 0)
             {
                 _stmtQueue.Dequeue().stmt.Dispose();
+            }
+
+            if (!disposing)
+            {
+                return;
             }
 
             _closed = true;


### PR DESCRIPTION
They would eventually get freed with the connection, but this will free them sooner when an undisposed reader is finalized and the connection is still open.

Fixes #351

This also re-enables API check (fixes #338)