### PR TITLE
Add BinaryGUID connection string to select binary/string GUID storage

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -219,18 +219,16 @@ namespace Microsoft.Data.Sqlite
             var changes = 0;
             var stmts = new Queue<(sqlite3_stmt, bool)>();
             var tail = CommandText;
+            int rc;
 
             do
             {
-                var rc = raw.sqlite3_prepare_v2(
-                        Connection.Handle,
-                        tail,
-                        out var stmt,
-                        out tail);
-                SqliteException.ThrowExceptionForRC(rc, Connection.Handle);
+                var stmtTuple = Connection.CreateStatement(tail);
+                var stmt = stmtTuple.Statement;
+                tail = stmtTuple.Tail;
 
                 // Statement was empty, white space, or a comment
-                if (stmt.ptr == IntPtr.Zero)
+                if (stmt.Ptr == IntPtr.Zero)
                 {
                     if (!string.IsNullOrEmpty(tail))
                     {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -264,6 +264,18 @@ namespace Microsoft.Data.Sqlite
         protected override DbCommand CreateDbCommand()
             => CreateCommand();
 
+        internal (SqliteStatement Statement, string Tail) CreateStatement(string sql)
+        {
+            var rc = raw.sqlite3_prepare_v2(
+                    Handle,
+                    sql,
+                    out var stmt,
+                    out var tail);
+            SqliteException.ThrowExceptionForRC(rc, Handle);
+            var statement = new SqliteStatement(stmt, this);
+            return (statement, tail);
+        }
+
         /// <summary>
         /// Create custom collation.
         /// </summary>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnectionStringBuilder.cs
@@ -24,12 +24,16 @@ namespace Microsoft.Data.Sqlite
         private const string ModeKeyword = "Mode";
         private const string CacheKeyword = "Cache";
         private const string FilenameKeyword = "Filename";
+        private const string BinaryGUIDKeyword = "BinaryGUID";
+
+        private const bool BinaryGUIDDefault = true;
 
         private enum Keywords
         {
             DataSource,
             Mode,
-            Cache
+            Cache,
+            BinaryGUID
         }
 
         private static readonly IReadOnlyList<string> _validKeywords;
@@ -38,20 +42,23 @@ namespace Microsoft.Data.Sqlite
         private string _dataSource = string.Empty;
         private SqliteOpenMode _mode = SqliteOpenMode.ReadWriteCreate;
         private SqliteCacheMode _cache = SqliteCacheMode.Default;
+        private bool _binaryGUID = BinaryGUIDDefault;
 
         static SqliteConnectionStringBuilder()
         {
-            var validKeywords = new string[3];
+            var validKeywords = new string[4];
             validKeywords[(int)Keywords.DataSource] = DataSourceKeyword;
             validKeywords[(int)Keywords.Mode] = ModeKeyword;
             validKeywords[(int)Keywords.Cache] = CacheKeyword;
+            validKeywords[(int)Keywords.BinaryGUID] = BinaryGUIDKeyword;
             _validKeywords = validKeywords;
 
-            _keywords = new Dictionary<string, Keywords>(3, StringComparer.OrdinalIgnoreCase)
+            _keywords = new Dictionary<string, Keywords>(4, StringComparer.OrdinalIgnoreCase)
             {
                 [DataSourceKeyword] = Keywords.DataSource,
                 [ModeKeyword] = Keywords.Mode,
                 [CacheKeyword] = Keywords.Cache,
+                [BinaryGUIDKeyword] = Keywords.BinaryGUID,
 
                 // aliases
                 [FilenameKeyword] = Keywords.DataSource,
@@ -132,6 +139,16 @@ namespace Microsoft.Data.Sqlite
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether GUIDs are stored in binary form.
+        /// </summary>
+        /// <value>A value indicating whether GUIDs are stored in binary form.</value>
+        public virtual bool BinaryGUID
+        {
+            get => _binaryGUID;
+            set => base[CacheKeyword] = _binaryGUID = value;
+        }
+
+        /// <summary>
         /// Gets or sets the value associated with the specified key.
         /// </summary>
         /// <param name="keyword">The key.</param>
@@ -160,6 +177,10 @@ namespace Microsoft.Data.Sqlite
 
                     case Keywords.Cache:
                         Cache = ConvertToEnum<SqliteCacheMode>(keyword, value);
+                        return;
+
+                    case Keywords.BinaryGUID:
+                        BinaryGUID = Convert.ToBoolean(value, CultureInfo.InvariantCulture);
                         return;
 
                     default:
@@ -281,6 +302,9 @@ namespace Microsoft.Data.Sqlite
                 case Keywords.Cache:
                     return Cache;
 
+                case Keywords.BinaryGUID:
+                    return BinaryGUID;
+
                 default:
                     Debug.Assert(false, "Unexpected keyword: " + index);
                     return null;
@@ -306,6 +330,10 @@ namespace Microsoft.Data.Sqlite
 
                 case Keywords.Cache:
                     _cache = SqliteCacheMode.Default;
+                    return;
+
+                case Keywords.BinaryGUID:
+                    _binaryGUID = BinaryGUIDDefault;
                     return;
 
                 default:

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -677,7 +677,12 @@ namespace Microsoft.Data.Sqlite
             return i;
         }
 
-        private byte[] GetBlob(int ordinal)
+        /// <summary>
+        /// Gets the value of the specified column as an array of bytes.
+        /// </summary>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <returns>The value of the column.</returns>
+        public virtual byte[] GetBlob(int ordinal)
             => IsDBNull(ordinal)
                 ? throw new InvalidCastException()
                 : raw.sqlite3_column_blob(_stmt, ordinal) ?? _emptyByteArray;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Data.Sqlite
             SqliteType = SqliteType.Text;
         }
 
-        internal bool Bind(sqlite3_stmt stmt)
+        internal bool Bind(SqliteStatement stmt)
         {
             if (_parameterName.Length == 0)
             {
@@ -262,8 +262,16 @@ namespace Microsoft.Data.Sqlite
                 }
                 else if (type == typeof(Guid))
                 {
-                    var value = ((Guid)_value).ToByteArray();
-                    _bindAction = (s, i) => BindBlob(s, i, value);
+                    if (stmt.BinaryGUID)
+                    {
+                        var value = ((Guid)_value).ToByteArray();
+                        _bindAction = (s, i) => BindBlob(s, i, value);
+                    }
+                    else
+                    {
+                        var value = ((Guid)_value).ToString();
+                        _bindAction = (s, i) => BindText(s, i, value);
+                    }
                 }
                 else if (type == typeof(int))
                 {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Data.Sqlite
         protected override void SetParameter(string parameterName, DbParameter value)
             => SetParameter(IndexOfChecked(parameterName), value);
 
-        internal int Bind(sqlite3_stmt stmt)
+        internal int Bind(SqliteStatement stmt)
         {
             var bound = 0;
             foreach (var parameter in _parameters)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteStatement.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteStatement.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Sqlite
+{
+    using System;
+    using SQLitePCL;
+
+    internal class SqliteStatement
+    {
+        private readonly SqliteConnection _connection;
+
+        public SqliteStatement(sqlite3_stmt stmt, SqliteConnection connection)
+        {
+            RawStatement = stmt;
+            _connection = connection;
+        }
+
+        private SqliteStatement() => throw new NotSupportedException();
+
+        public sqlite3_stmt RawStatement { get; }
+        public bool BinaryGUID => _connection.ConnectionStringBuilder.BinaryGUID;
+
+        public IntPtr Ptr => RawStatement.ptr;
+
+        public static implicit operator sqlite3_stmt(SqliteStatement stmt)
+        {
+            return stmt.RawStatement;
+        }
+
+        internal void Dispose() => RawStatement.Dispose();
+    }
+}

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
@@ -18,4 +18,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionStringBuilderTest.cs
@@ -92,10 +92,11 @@ namespace Microsoft.Data.Sqlite
             var keys = (ICollection<string>)new SqliteConnectionStringBuilder().Keys;
 
             Assert.True(keys.IsReadOnly);
-            Assert.Equal(3, keys.Count);
+            Assert.Equal(4, keys.Count);
             Assert.Contains("Data Source", keys);
             Assert.Contains("Mode", keys);
             Assert.Contains("Cache", keys);
+            Assert.Contains("BinaryGUID", keys);
         }
 
         [Fact]
@@ -104,7 +105,7 @@ namespace Microsoft.Data.Sqlite
             var values = (ICollection<object>)new SqliteConnectionStringBuilder().Values;
 
             Assert.True(values.IsReadOnly);
-            Assert.Equal(3, values.Count);
+            Assert.Equal(4, values.Count);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -312,6 +312,60 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void BinaryGUID_true_works()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:;BinaryGUID=true"))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Test(Value);");
+
+                var command = connection.CreateCommand();
+                command.CommandText = "INSERT INTO Test VALUES(@p1);";
+
+                var guid = new Guid("1c902ddb-f4b6-4945-af38-0dc1b0760465");
+                command.Parameters.AddWithValue("@p1", guid);
+                Assert.Equal(1, command.ExecuteNonQuery());
+
+                command.CommandText = "SELECT Value FROM Test;";
+                using (var reader = command.ExecuteReader())
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    Assert.Equal("BLOB", reader.GetDataTypeName(0));
+                    Assert.Equal(new byte[] { 0xDB, 0x2D, 0x90, 0x1C, 0xB6, 0xF4, 0x45, 0x49, 0xAF, 0x38, 0x0D, 0xC1, 0xB0, 0x76, 0x04, 0x65 }, reader.GetBlob(0));
+                }
+            }
+        }
+
+        [Fact]
+        public void BinaryGUID_false_works()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:;BinaryGUID=false"))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Test(Value);");
+
+                var command = connection.CreateCommand();
+                command.CommandText = "INSERT INTO Test VALUES(@p1);";
+
+                var guid = new Guid("1c902ddb-f4b6-4945-af38-0dc1b0760465");
+                command.Parameters.AddWithValue("@p1", guid);
+                Assert.Equal(1, command.ExecuteNonQuery());
+
+                command.CommandText = "SELECT Value FROM Test;";
+                using (var reader = command.ExecuteReader())
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    Assert.Equal("TEXT", reader.GetDataTypeName(0));
+                    Assert.Equal("1c902ddb-f4b6-4945-af38-0dc1b0760465", reader.GetString(0));
+                }
+            }
+        }
+
+        [Fact]
         public void CreateCollation_works()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))


### PR DESCRIPTION
Addresses #273.

To be able to access the new BinaryGUID property in ConnectionStringBuilder from the parameter binding I added a wrapper around the sqlite3_stmt object and add the associated connection to it.