### PR TITLE
[WIP] Target .NET Standard 2.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,7 @@
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- TODO: Remove -->
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/common.props
+++ b/build/common.props
@@ -10,11 +10,13 @@
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <PackageTags>SQLite;Data;ADO.NET</PackageTags>
+    <!-- TODO: Remove -->    
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(OutputType)' == 'library' And '$(DisableImplicitFrameworkReferences)' != 'true'">
-    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <SQLitePCLRawVersion>1.1.5</SQLitePCLRawVersion>

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -17,7 +17,7 @@ Microsoft.Data.Sqlite.SqliteException
 Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
-    <TargetFrameworks>net451;netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.2;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)$(MSBuildProjectName).ruleset</CodeAnalysisRuleSet>
     <IncludeSymbols>true</IncludeSymbols>
@@ -37,6 +37,8 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="System.Data.Common" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Data.Sqlite
 
                         raw.sqlite3_reset(stmt);
 
-#if NET451
+#if NET451 || NETSTANDARD2_0
                         // TODO: Consider having an async path that uses Task.Delay()
                         Thread.Sleep(150);
 #endif

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.Sqlite.Properties;
 using Microsoft.Data.Sqlite.Utilities;
 using SQLitePCL;
 
-#if NET451
+#if NET451 || NETSTANDARD2_0
 using System.IO;
 #endif
 
@@ -196,7 +196,7 @@ namespace Microsoft.Data.Sqlite
                     break;
             }
 
-#if NET451
+#if NET451 || NETSTANDARD2_0
             var dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory") as string;
             if (!string.IsNullOrEmpty(dataDirectory)
                 && (flags & raw.SQLITE_OPEN_URI) == 0

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Data.Sqlite
             return true;
         }
 
-#if NET451 // NB: This works around dotnet/corefx#2249
+#if NET451 || NETSTANDARD2_0
         /// <summary>
         /// Closes the data reader.
         /// </summary>

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -691,7 +691,7 @@ namespace Microsoft.Data.Sqlite
                 connection.Open();
 
                 var reader = connection.ExecuteReader("SELECT 1;");
-#if NET46
+#if NET46 || NETSTANDARD2_0
                 reader.Close();
 #elif NETCOREAPP2_0
                 ((IDisposable)reader).Dispose();


### PR DESCRIPTION
Blocked on mirroring the 4.4.0 corefx packages
Blocked on API Check (throws *Could not load assembly 'netstandard'.*)

Open question:
* Should we test on `netcoreapp1.1` to cover the `netstandard1.2` assembly?
