### PR TITLE
Target .NET Standard 1.4 & 2.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -18,8 +18,9 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(OutputType)' == 'library' And '$(DisableImplicitFrameworkReferences)' != 'true'">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  <!-- TODO: Remove when dotnet/sdk#1220 is fixed -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETFrameworkPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
-    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
     <SQLitePCLRawVersion>1.1.5</SQLitePCLRawVersion>
     <StyleCopAnalyzersVersion>1.0.0</StyleCopAnalyzersVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,6 +3,7 @@
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
+    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <SQLitePCLRawVersion>1.1.5</SQLitePCLRawVersion>
     <StyleCopAnalyzersVersion>1.0.0</StyleCopAnalyzersVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -17,7 +17,7 @@ Microsoft.Data.Sqlite.SqliteException
 Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
-    <TargetFrameworks>net451;netstandard1.2</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.Data.Sqlite.Core.ruleset</CodeAnalysisRuleSet>
     <IncludeSymbols>true</IncludeSymbols>
@@ -32,11 +32,7 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
 
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" Version="$(SQLitePCLRawVersion)" />
-    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Data.Common" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
+++ b/src/Microsoft.Data.Sqlite.Core/Microsoft.Data.Sqlite.Core.csproj
@@ -17,7 +17,7 @@ Microsoft.Data.Sqlite.SqliteException
 Microsoft.Data.Sqlite.SqliteFactory
 Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>Microsoft.Data.Sqlite.Core.ruleset</CodeAnalysisRuleSet>
     <IncludeSymbols>true</IncludeSymbols>
@@ -33,6 +33,11 @@ Microsoft.Data.Sqlite.SqliteTransaction</Description>
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" Version="$(SQLitePCLRawVersion)" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
+    <PackageReference Include="System.Data.Common" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -278,10 +278,8 @@ namespace Microsoft.Data.Sqlite
 
                         raw.sqlite3_reset(stmt);
 
-#if NET451
                         // TODO: Consider having an async path that uses Task.Delay()
                         Thread.Sleep(150);
-#endif
                     }
 
                     SqliteException.ThrowExceptionForRC(rc, Connection.Handle);

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -278,8 +278,10 @@ namespace Microsoft.Data.Sqlite
 
                         raw.sqlite3_reset(stmt);
 
+#if NETSTANDARD2_0
                         // TODO: Consider having an async path that uses Task.Delay()
                         Thread.Sleep(150);
+#endif
                     }
 
                     SqliteException.ThrowExceptionForRC(rc, Connection.Handle);

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -5,10 +5,13 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
-using System.IO;
 using Microsoft.Data.Sqlite.Properties;
 using Microsoft.Data.Sqlite.Utilities;
 using SQLitePCL;
+
+#if NETSTANDARD2_0
+using System.IO;
+#endif
 
 namespace Microsoft.Data.Sqlite
 {
@@ -193,6 +196,7 @@ namespace Microsoft.Data.Sqlite
                     break;
             }
 
+#if NETSTANDARD2_0
             var dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory") as string;
             if (!string.IsNullOrEmpty(dataDirectory)
                 && (flags & raw.SQLITE_OPEN_URI) == 0
@@ -201,6 +205,7 @@ namespace Microsoft.Data.Sqlite
             {
                 filename = Path.Combine(dataDirectory, filename);
             }
+#endif
 
             var rc = raw.sqlite3_open_v2(filename, out _db, flags, vfs: null);
             SqliteException.ThrowExceptionForRC(rc, _db);

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -1,17 +1,14 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.IO;
 using Microsoft.Data.Sqlite.Properties;
 using Microsoft.Data.Sqlite.Utilities;
 using SQLitePCL;
-
-#if NET451
-using System.IO;
-#endif
 
 namespace Microsoft.Data.Sqlite
 {
@@ -196,7 +193,6 @@ namespace Microsoft.Data.Sqlite
                     break;
             }
 
-#if NET451
             var dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory") as string;
             if (!string.IsNullOrEmpty(dataDirectory)
                 && (flags & raw.SQLITE_OPEN_URI) == 0
@@ -205,7 +201,6 @@ namespace Microsoft.Data.Sqlite
             {
                 filename = Path.Combine(dataDirectory, filename);
             }
-#endif
 
             var rc = raw.sqlite3_open_v2(filename, out _db, flags, vfs: null);
             SqliteException.ThrowExceptionForRC(rc, _db);
@@ -277,7 +272,7 @@ namespace Microsoft.Data.Sqlite
         /// </summary>
         /// <typeparam name="T">The type of the state object.</typeparam>
         /// <param name="name">Name of the collation.</param>
-        /// <param name="state">State object passed to each invokation of the collation.</param>
+        /// <param name="state">State object passed to each invocation of the collation.</param>
         /// <param name="comparison">Method that compares two strings, using additional state.</param>
         public virtual void CreateCollation<T>(string name, T state, Func<T, string, string, int> comparison)
         {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -159,11 +159,13 @@ namespace Microsoft.Data.Sqlite
             return true;
         }
 
+#if NETSTANDARD2_0
         /// <summary>
         /// Closes the data reader.
         /// </summary>
         public override void Close()
             => Dispose(true);
+#endif
 
         /// <summary>
         /// Releases any resources used by the data reader and closes it.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -159,13 +159,11 @@ namespace Microsoft.Data.Sqlite
             return true;
         }
 
-#if NET451 // NB: This works around dotnet/corefx#2249
         /// <summary>
         /// Closes the data reader.
         /// </summary>
         public override void Close()
             => Dispose(true);
-#endif
 
         /// <summary>
         /// Releases any resources used by the data reader and closes it.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="rc">The SQLite error code corresponding to the desired exception.</param>
         /// <param name="db">A handle to database connection.</param>
         /// <remarks>
-        /// No exception is thrown forn non-error result codes.
+        /// No exception is thrown for non-error result codes.
         /// </remarks>
         public static void ThrowExceptionForRC(int rc, sqlite3 db)
         {

--- a/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
+++ b/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
@@ -16,7 +16,8 @@ Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnableApiCheck>false</EnableApiCheck>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
+++ b/src/Microsoft.Data.Sqlite/Microsoft.Data.Sqlite.csproj
@@ -16,8 +16,7 @@ Microsoft.Data.Sqlite.SqliteParameter
 Microsoft.Data.Sqlite.SqliteTransaction</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnableApiCheck>false</EnableApiCheck>
-    <TargetFrameworks>net451;netstandard1.2</TargetFrameworks>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -691,13 +691,7 @@ namespace Microsoft.Data.Sqlite
                 connection.Open();
 
                 var reader = connection.ExecuteReader("SELECT 1;");
-#if NET46
                 reader.Close();
-#elif NETCOREAPP2_0
-                ((IDisposable)reader).Dispose();
-#else
-#error Target framework needs to be updated
-#endif
 
                 Assert.True(reader.IsClosed);
             }


### PR DESCRIPTION
Ideally, we'd just target .NET Standard 2.0, but since it will take a few months for UWP to support it, we'll cross-target 1.4 in the mean time. (See https://github.com/aspnet/Microsoft.Data.Sqlite/pull/370/commits/64319deb873fea6df8d9903ce3fd4997a07a89f9 for the code we'll be able to remvoe.)

Blocked waiting on updates to KoreBuild

Resolves #350