### PR TITLE
Update to SQLitePCLRaw 1.1.6

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
-    <SQLitePCLRawVersion>1.1.3</SQLitePCLRawVersion>
+    <SQLitePCLRawVersion>1.1.6</SQLitePCLRawVersion>
     <StyleCopAnalyzersVersion>1.0.0</StyleCopAnalyzersVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>


### PR DESCRIPTION
This version resolves issues with ns2.0 compatibility and AssetTargetFallback.

Thanks to @ericsink for the update.

See also:
 - Update third-party list https://github.com/aspnet/BuildTools/pull/275
 - Update EF https://github.com/aspnet/EntityFramework/pull/8890
 - Remove workarounds from metapackage https://github.com/aspnet/MetaPackages/pull/164

Fixes https://github.com/aspnet/External/issues/59