### PR TITLE
Upgrade SQLitePCLRaw to 1.1.7

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETFrameworkPackageVersion>2.0.0-*</NETFrameworkPackageVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
-    <SQLitePCLRawVersion>1.1.3</SQLitePCLRawVersion>
+    <SQLitePCLRawVersion>1.1.7</SQLitePCLRawVersion>
     <StyleCopAnalyzersVersion>1.0.0</StyleCopAnalyzersVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>


### PR DESCRIPTION
This bundles SQLite 3.18.2 and has improved support for .NET Standard 2.0 and NuGet 4.3.

cc @ericsink