### PR TITLE
Ensure decimal point in decimal parameters

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Sqlite
                 }
                 else if (type == typeof(decimal))
                 {
-                    var value = ((decimal)_value).ToString(CultureInfo.InvariantCulture);
+                    var value = ((decimal)_value).ToString("0.0###########################", CultureInfo.InvariantCulture);
                     _bindAction = (s, i) => BindText(s, i, value);
                 }
                 else if (type == typeof(double))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -221,6 +221,10 @@ namespace Microsoft.Data.Sqlite
             => Bind_works(3.14m, "3.14");
 
         [Fact]
+        public void Bind_works_when_decimal_with_integral_value()
+            => Bind_works(3m, "3.0");
+
+        [Fact]
         public void Bind_works_when_Enum()
             => Bind_works(MyEnum.One, 1L);
 


### PR DESCRIPTION
This prevents integer results when performing arithmetic operations on decimal parameters. For example, consider the following query.
```SQL
SELECT 1 / $value;
```
Where `value` is the following in C#.
```C#
decimal value = 2m;
```
Here is a table illustrating the improved result.

Microsoft.Data.Sqlite | Result
--- | ---
**1.x** |  0
**2.0.0** | 0.5

## Breaking change
You may encounter a breaking change if you previously saved integral decimal values into a column using version 1.x and try to query for equality in version 2.0.0.

For example, if you previously saved the value `3m` into `DecimalColumn` and try the following query in version 2.0 (where `$value` is also `3m`) it will return no results.
```SQL
SELECT *
FROM MyTable
WHERE DecimalColumn = $value;
--              '3' = '3.0'   (False)
```

To upgrade your database to be fully compatible with decimal parameters in version 2.0.0, you'll need to use `UPDATE` statements like the following.

```SQL
UPDATE MyTable
SET DecimalColumn = DecimalColumn + '.0'
WHERE instr(DecimalColumn, '.') = 0;
```

**Note**, reading decimal columns with `SqliteDataReader` will yield the same values as before. It's only SQL equality comparisons that are affected.