### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -12,6 +12,7 @@
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <PackageTags>SQLite;Data;ADO.NET</PackageTags>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings