### PR TITLE
Fix broken reuse of SqliteCommand

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -322,6 +322,11 @@ namespace Microsoft.Data.Sqlite
                     ? PrepareAndEnumerateStatements()
                     : _preparedStatements)
                 {
+                    if (!unprepared)
+                    {
+                        raw.sqlite3_reset(stmt);
+                    }
+
                     var boundParams = 0;
 
                     if (_parameters.IsValueCreated)

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -322,11 +322,6 @@ namespace Microsoft.Data.Sqlite
                     ? PrepareAndEnumerateStatements()
                     : _preparedStatements)
                 {
-                    if (!unprepared)
-                    {
-                        raw.sqlite3_reset(stmt);
-                    }
-
                     var boundParams = 0;
 
                     if (_parameters.IsValueCreated)
@@ -378,6 +373,7 @@ namespace Microsoft.Data.Sqlite
                     }
                     else
                     {
+                        raw.sqlite3_reset(stmt);
                         hasChanges = true;
                         changes += raw.sqlite3_changes(_connection.Handle);
                     }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -178,15 +178,12 @@ namespace Microsoft.Data.Sqlite
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE Data (ID integer PRIMARY KEY, Value integer);");
 
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = "CREATE TABLE Data (ID integer PRIMARY KEY, Value integer);";
-                    command.ExecuteNonQuery();
-
                     command.CommandText = "INSERT INTO Data (Value) VALUES (@value);";
-                    var valueParam = new SqliteParameter { ParameterName = "@value", Value = -1 };
-                    command.Parameters.Add(valueParam);
+                    var valueParam = command.Parameters.AddWithValue("@value", -1);
 
                     Assert.Equal(1, command.ExecuteNonQuery());
 


### PR DESCRIPTION
According to http://sqlite.org/c3ref/stmt.html the life cycle of a prepared statement looks like this:

1. Create the prepared statement object using sqlite3_prepare_v2(). 
2. Bind values to parameters using the sqlite3_bind_*() interfaces. 
3. Run the SQL by calling sqlite3_step() one or more times. 
4. Reset the prepared statement using sqlite3_reset() then go back to step 2. Do this zero or more times. 
5. Destroy the object using sqlite3_finalize(). 

Since we now store and reuse prepared statements we have to reset them before rebinding (4->2).
This reset got lost somewhere in the process of adding the Prepare() command.

Addresses #394 
