### PR TITLE
Add initial implementation of GetSchemaTable

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -533,7 +533,7 @@ namespace Microsoft.Data.Sqlite
                 schemaRow[IsExpression] = raw.sqlite3_column_origin_name(_stmt, i) == null;
                 //schemaRow[IsRowVersion] = null;
                 //schemaRow[IsHidden] = null;
-                schemaRow[IsLong] = GetFieldType(i) == typeof(long);
+                schemaRow[IsLong] = DBNull.Value;
                 //schemaRow[IsReadOnly] = null;
                 //schemaRow[ProviderSpecificDataType] = null;
                 //schemaRow[NonVersionedProviderType] = null;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -448,26 +448,20 @@ namespace Microsoft.Data.Sqlite
             var schemaTable = new DataTable("SchemaTable");
 
             var ColumnName = new DataColumn(SchemaTableColumn.ColumnName, typeof(string));
-            var Ordinal = new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(int));
-            var Size = new DataColumn(SchemaTableColumn.ColumnSize, typeof(int));
-            var Precision = new DataColumn(SchemaTableColumn.NumericPrecision, typeof(short));
-            var Scale = new DataColumn(SchemaTableColumn.NumericScale, typeof(short));
+            var ColumnOrdinal = new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(int));
+            var ColumnSize = new DataColumn(SchemaTableColumn.ColumnSize, typeof(int));
+            var NumericPrecision = new DataColumn(SchemaTableColumn.NumericPrecision, typeof(short));
+            var NumericScale = new DataColumn(SchemaTableColumn.NumericScale, typeof(short));
 
             var DataType = new DataColumn(SchemaTableColumn.DataType, typeof(Type));
             var DataTypeName = new DataColumn("DataTypeName", typeof(string));
-            var ProviderSpecificDataType = new DataColumn(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(Type));
-            var ProviderType = new DataColumn(SchemaTableColumn.ProviderType, typeof(int));
-            var NonVersionedProviderType = new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(int));
 
             var IsLong = new DataColumn(SchemaTableColumn.IsLong, typeof(bool));
             var AllowDBNull = new DataColumn(SchemaTableColumn.AllowDBNull, typeof(bool));
-            var IsReadOnly = new DataColumn(SchemaTableOptionalColumn.IsReadOnly, typeof(bool));
-            var IsRowVersion = new DataColumn(SchemaTableOptionalColumn.IsRowVersion, typeof(bool));
 
             var IsUnique = new DataColumn(SchemaTableColumn.IsUnique, typeof(bool));
             var IsKey = new DataColumn(SchemaTableColumn.IsKey, typeof(bool));
             var IsAutoIncrement = new DataColumn(SchemaTableOptionalColumn.IsAutoIncrement, typeof(bool));
-            var IsHidden = new DataColumn(SchemaTableOptionalColumn.IsHidden, typeof(bool));
 
             var BaseCatalogName = new DataColumn(SchemaTableOptionalColumn.BaseCatalogName, typeof(string));
             var BaseSchemaName = new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(string));
@@ -477,68 +471,50 @@ namespace Microsoft.Data.Sqlite
             var BaseServerName = new DataColumn(SchemaTableOptionalColumn.BaseServerName, typeof(string));
             var IsAliased = new DataColumn(SchemaTableColumn.IsAliased, typeof(bool));
             var IsExpression = new DataColumn(SchemaTableColumn.IsExpression, typeof(bool));
-            var IsIdentity = new DataColumn("IsIdentity", typeof(bool));
-            var UdtAssemblyQualifiedName = new DataColumn("UdtAssemblyQualifiedName", typeof(string));
 
             var columns = schemaTable.Columns;
 
             columns.Add(ColumnName);
-            columns.Add(Ordinal);
-            //columns.Add(Size);
-            //columns.Add(Precision);
-            //columns.Add(Scale);
+            columns.Add(ColumnOrdinal);
+            columns.Add(ColumnSize);
+            columns.Add(NumericPrecision);
+            columns.Add(NumericScale);
             columns.Add(IsUnique);
             columns.Add(IsKey);
             columns.Add(BaseServerName);
             columns.Add(BaseCatalogName);
             columns.Add(BaseColumnName);
-            //columns.Add(BaseSchemaName);
+            columns.Add(BaseSchemaName);
             columns.Add(BaseTableName);
             columns.Add(DataType);
             columns.Add(DataTypeName);
             columns.Add(AllowDBNull);
-            //columns.Add(ProviderType);
             columns.Add(IsAliased);
             columns.Add(IsExpression);
             columns.Add(IsAutoIncrement);
-            //columns.Add(IsRowVersion);
-            //columns.Add(IsHidden);
             columns.Add(IsLong);
-            //columns.Add(IsReadOnly);
-            //columns.Add(ProviderSpecificDataType);
-            //columns.Add(NonVersionedProviderType);
-            //columns.Add(IsIdentity);
-            //columns.Add(UdtAssemblyQualifiedName);
 
             for (var i = 0; i < FieldCount; i++)
             {
                 var schemaRow = schemaTable.NewRow();
                 schemaRow[ColumnName] = GetName(i);
-                schemaRow[Ordinal] = i;
-                //schemaRow[Size] = null;
-                //schemaRow[Precision] = null;
-                //schemaRow[Scale] = null;
+                schemaRow[ColumnOrdinal] = i;
+                schemaRow[ColumnSize] = DBNull.Value;
+                schemaRow[NumericPrecision] = DBNull.Value;
+                schemaRow[NumericScale] = DBNull.Value;
                 schemaRow[BaseServerName] = _command.Connection.DataSource;
                 var databaseName = raw.sqlite3_column_database_name(_stmt, i);
                 schemaRow[BaseCatalogName] = databaseName;
                 var columnName = raw.sqlite3_column_origin_name(_stmt, i);
                 schemaRow[BaseColumnName] = columnName;
-                //schemaRow[BaseSchemaName] = null;
+                schemaRow[BaseSchemaName] = DBNull.Value;
                 var tableName = raw.sqlite3_column_table_name(_stmt, i);
                 schemaRow[BaseTableName] = tableName;
                 schemaRow[DataType] = GetFieldType(i);
                 schemaRow[DataTypeName] = GetDataTypeName(i);
-                //schemaRow[ProviderType] = null;
-                schemaRow[IsAliased] = raw.sqlite3_column_origin_name(_stmt, i) != GetName(i);
-                schemaRow[IsExpression] = raw.sqlite3_column_origin_name(_stmt, i) == null;
-                //schemaRow[IsRowVersion] = null;
-                //schemaRow[IsHidden] = null;
+                schemaRow[IsAliased] = columnName != GetName(i);
+                schemaRow[IsExpression] = columnName == null;
                 schemaRow[IsLong] = DBNull.Value;
-                //schemaRow[IsReadOnly] = null;
-                //schemaRow[ProviderSpecificDataType] = null;
-                //schemaRow[NonVersionedProviderType] = null;
-                //schemaRow[IsIdentity] = null;
-                //schemaRow[UdtAssemblyQualifiedName] = null;
 
                 if (!string.IsNullOrEmpty(tableName) && !string.IsNullOrEmpty(columnName))
                 {

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
+using System.Text;
 using Microsoft.Data.Sqlite.Properties;
 using SQLitePCL;
 
@@ -436,5 +438,139 @@ namespace Microsoft.Data.Sqlite
         /// <returns>The number of values copied into the array.</returns>
         public override int GetValues(object[] values)
             => _record.GetValues(values);
+
+        /// <summary>
+        /// Returns a System.Data.DataTable that describes the column metadata of the System.Data.Common.DbDataReader.
+        /// </summary>
+        /// <returns>A System.Data.DataTable that describes the column metadata.</returns>
+        public override DataTable GetSchemaTable()
+        {
+            var schemaTable = new DataTable("SchemaTable");
+
+            var ColumnName = new DataColumn(SchemaTableColumn.ColumnName, typeof(string));
+            var Ordinal = new DataColumn(SchemaTableColumn.ColumnOrdinal, typeof(int));
+            var Size = new DataColumn(SchemaTableColumn.ColumnSize, typeof(int));
+            var Precision = new DataColumn(SchemaTableColumn.NumericPrecision, typeof(short));
+            var Scale = new DataColumn(SchemaTableColumn.NumericScale, typeof(short));
+
+            var DataType = new DataColumn(SchemaTableColumn.DataType, typeof(Type));
+            var DataTypeName = new DataColumn("DataTypeName", typeof(string));
+            var ProviderSpecificDataType = new DataColumn(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(Type));
+            var ProviderType = new DataColumn(SchemaTableColumn.ProviderType, typeof(int));
+            var NonVersionedProviderType = new DataColumn(SchemaTableColumn.NonVersionedProviderType, typeof(int));
+
+            var IsLong = new DataColumn(SchemaTableColumn.IsLong, typeof(bool));
+            var AllowDBNull = new DataColumn(SchemaTableColumn.AllowDBNull, typeof(bool));
+            var IsReadOnly = new DataColumn(SchemaTableOptionalColumn.IsReadOnly, typeof(bool));
+            var IsRowVersion = new DataColumn(SchemaTableOptionalColumn.IsRowVersion, typeof(bool));
+
+            var IsUnique = new DataColumn(SchemaTableColumn.IsUnique, typeof(bool));
+            var IsKey = new DataColumn(SchemaTableColumn.IsKey, typeof(bool));
+            var IsAutoIncrement = new DataColumn(SchemaTableOptionalColumn.IsAutoIncrement, typeof(bool));
+            var IsHidden = new DataColumn(SchemaTableOptionalColumn.IsHidden, typeof(bool));
+
+            var BaseCatalogName = new DataColumn(SchemaTableOptionalColumn.BaseCatalogName, typeof(string));
+            var BaseSchemaName = new DataColumn(SchemaTableColumn.BaseSchemaName, typeof(string));
+            var BaseTableName = new DataColumn(SchemaTableColumn.BaseTableName, typeof(string));
+            var BaseColumnName = new DataColumn(SchemaTableColumn.BaseColumnName, typeof(string));
+
+            var BaseServerName = new DataColumn(SchemaTableOptionalColumn.BaseServerName, typeof(string));
+            var IsAliased = new DataColumn(SchemaTableColumn.IsAliased, typeof(bool));
+            var IsExpression = new DataColumn(SchemaTableColumn.IsExpression, typeof(bool));
+            var IsIdentity = new DataColumn("IsIdentity", typeof(bool));
+            var UdtAssemblyQualifiedName = new DataColumn("UdtAssemblyQualifiedName", typeof(string));
+
+            var columns = schemaTable.Columns;
+
+            columns.Add(ColumnName);
+            columns.Add(Ordinal);
+            //columns.Add(Size);
+            //columns.Add(Precision);
+            //columns.Add(Scale);
+            columns.Add(IsUnique);
+            columns.Add(IsKey);
+            columns.Add(BaseServerName);
+            columns.Add(BaseCatalogName);
+            columns.Add(BaseColumnName);
+            //columns.Add(BaseSchemaName);
+            columns.Add(BaseTableName);
+            columns.Add(DataType);
+            columns.Add(DataTypeName);
+            columns.Add(AllowDBNull);
+            //columns.Add(ProviderType);
+            columns.Add(IsAliased);
+            columns.Add(IsExpression);
+            columns.Add(IsAutoIncrement);
+            //columns.Add(IsRowVersion);
+            //columns.Add(IsHidden);
+            columns.Add(IsLong);
+            //columns.Add(IsReadOnly);
+            //columns.Add(ProviderSpecificDataType);
+            //columns.Add(NonVersionedProviderType);
+            //columns.Add(IsIdentity);
+            //columns.Add(UdtAssemblyQualifiedName);
+
+            for (var i = 0; i < FieldCount; i++)
+            {
+                var schemaRow = schemaTable.NewRow();
+                schemaRow[ColumnName] = GetName(i);
+                schemaRow[Ordinal] = i;
+                //schemaRow[Size] = null;
+                //schemaRow[Precision] = null;
+                //schemaRow[Scale] = null;
+                schemaRow[BaseServerName] = _command.Connection.DataSource;
+                var databaseName = raw.sqlite3_column_database_name(_stmt, i);
+                schemaRow[BaseCatalogName] = databaseName;
+                var columnName = raw.sqlite3_column_origin_name(_stmt, i);
+                schemaRow[BaseColumnName] = columnName;
+                //schemaRow[BaseSchemaName] = null;
+                var tableName = raw.sqlite3_column_table_name(_stmt, i);
+                schemaRow[BaseTableName] = tableName;
+                schemaRow[DataType] = GetFieldType(i);
+                schemaRow[DataTypeName] = GetDataTypeName(i);
+                //schemaRow[ProviderType] = null;
+                schemaRow[IsAliased] = raw.sqlite3_column_origin_name(_stmt, i) != GetName(i);
+                schemaRow[IsExpression] = raw.sqlite3_column_origin_name(_stmt, i) == null;
+                //schemaRow[IsRowVersion] = null;
+                //schemaRow[IsHidden] = null;
+                schemaRow[IsLong] = GetFieldType(i) == typeof(long);
+                //schemaRow[IsReadOnly] = null;
+                //schemaRow[ProviderSpecificDataType] = null;
+                //schemaRow[NonVersionedProviderType] = null;
+                //schemaRow[IsIdentity] = null;
+                //schemaRow[UdtAssemblyQualifiedName] = null;
+
+                if (!string.IsNullOrEmpty(tableName) && !string.IsNullOrEmpty(columnName))
+                {
+                    using (var command = _command.Connection.CreateCommand())
+                    {
+                        command.CommandText = new StringBuilder()
+                            .AppendLine("SELECT COUNT(*)")
+                            .AppendLine("FROM pragma_index_list($table) i, pragma_index_info(i.name) c")
+                            .AppendLine("WHERE \"unique\" = 1 AND c.name = $column AND")
+                            .AppendLine("NOT EXISTS (SELECT * FROM pragma_index_info(i.name) c2 WHERE c2.name != c.name);").ToString();
+                        command.Parameters.AddWithValue("$table", tableName);
+                        command.Parameters.AddWithValue("$column", columnName);
+
+                        var cnt = (long)command.ExecuteScalar();
+                        schemaRow[IsUnique] = cnt != 0;
+                    }
+
+                    if (!string.IsNullOrEmpty(databaseName))
+                    {
+                        var rc = raw.sqlite3_table_column_metadata(_command.Connection.Handle, databaseName, tableName, columnName, out var dataType, out var collSeq, out var notNull, out var primaryKey, out var autoInc);
+                        SqliteException.ThrowExceptionForRC(rc, _command.Connection.Handle);
+
+                        schemaRow[IsKey] = primaryKey != 0;
+                        schemaRow[AllowDBNull] = notNull == 0;
+                        schemaRow[IsAutoIncrement] = autoInc != 0;
+                    }
+                }
+
+                schemaTable.Rows.Add(schemaRow);
+            }
+
+            return schemaTable;
+        }
     }
 }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -938,11 +938,15 @@ namespace Microsoft.Data.Sqlite
                     var schema = reader.GetSchemaTable();
                     Assert.True(schema.Columns.Contains("ColumnName"));
                     Assert.True(schema.Columns.Contains("ColumnOrdinal"));
+                    Assert.True(schema.Columns.Contains("ColumnSize"));
+                    Assert.True(schema.Columns.Contains("NumericPrecision"));
+                    Assert.True(schema.Columns.Contains("NumericScale"));
                     Assert.True(schema.Columns.Contains("IsUnique"));
                     Assert.True(schema.Columns.Contains("IsKey"));
                     Assert.True(schema.Columns.Contains("BaseServerName"));
                     Assert.True(schema.Columns.Contains("BaseCatalogName"));
                     Assert.True(schema.Columns.Contains("BaseColumnName"));
+                    Assert.True(schema.Columns.Contains("BaseSchemaName"));
                     Assert.True(schema.Columns.Contains("BaseTableName"));
                     Assert.True(schema.Columns.Contains("DataType"));
                     Assert.True(schema.Columns.Contains("DataTypeName"));
@@ -956,11 +960,15 @@ namespace Microsoft.Data.Sqlite
 
                     Assert.Equal("LastName", schema.Rows[0]["ColumnName"]);
                     Assert.Equal(0, schema.Rows[0]["ColumnOrdinal"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[0]["ColumnSize"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[0]["NumericPrecision"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[0]["NumericScale"]);
                     Assert.False((bool)schema.Rows[0]["IsUnique"]);
                     Assert.False((bool)schema.Rows[0]["IsKey"]);
                     Assert.Equal("", schema.Rows[0]["BaseServerName"]);
                     Assert.Equal("main", schema.Rows[0]["BaseCatalogName"]);
                     Assert.Equal("LastName", schema.Rows[0]["BaseColumnName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[0]["BaseSchemaName"]);
                     Assert.Equal("Person", schema.Rows[0]["BaseTableName"]);
                     Assert.Equal(typeof(String), schema.Rows[0]["DataType"]);
                     Assert.Equal("TEXT", schema.Rows[0]["DataTypeName"]);
@@ -972,11 +980,15 @@ namespace Microsoft.Data.Sqlite
 
                     Assert.Equal("ID", schema.Rows[1]["ColumnName"]);
                     Assert.Equal(1, schema.Rows[1]["ColumnOrdinal"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[1]["ColumnSize"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[1]["NumericPrecision"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[1]["NumericScale"]);
                     Assert.False((bool)schema.Rows[1]["IsUnique"]);
                     Assert.True((bool)schema.Rows[1]["IsKey"]);
                     Assert.Equal("", schema.Rows[1]["BaseServerName"]);
                     Assert.Equal("main", schema.Rows[1]["BaseCatalogName"]);
                     Assert.Equal("ID", schema.Rows[1]["BaseColumnName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[1]["BaseSchemaName"]);
                     Assert.Equal("Person", schema.Rows[1]["BaseTableName"]);
                     Assert.Equal(typeof(Int64), schema.Rows[1]["DataType"]);
                     Assert.Equal("INTEGER", schema.Rows[1]["DataTypeName"]);
@@ -988,11 +1000,15 @@ namespace Microsoft.Data.Sqlite
 
                     Assert.Equal("Code", schema.Rows[2]["ColumnName"]);
                     Assert.Equal(2, schema.Rows[2]["ColumnOrdinal"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[2]["ColumnSize"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[2]["NumericPrecision"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[2]["NumericScale"]);
                     Assert.True((bool)schema.Rows[2]["IsUnique"]);
                     Assert.False((bool)schema.Rows[2]["IsKey"]);
                     Assert.Equal("", schema.Rows[2]["BaseServerName"]);
                     Assert.Equal("main", schema.Rows[2]["BaseCatalogName"]);
                     Assert.Equal("Code", schema.Rows[2]["BaseColumnName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[2]["BaseSchemaName"]);
                     Assert.Equal("Person", schema.Rows[2]["BaseTableName"]);
                     Assert.Equal(typeof(Int64), schema.Rows[2]["DataType"]);
                     Assert.Equal("INT", schema.Rows[2]["DataTypeName"]);
@@ -1004,11 +1020,15 @@ namespace Microsoft.Data.Sqlite
 
                     Assert.Equal("IncID", schema.Rows[3]["ColumnName"]);
                     Assert.Equal(3, schema.Rows[3]["ColumnOrdinal"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["ColumnSize"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["NumericPrecision"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["NumericScale"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["IsUnique"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["IsKey"]);
                     Assert.Equal("", schema.Rows[3]["BaseServerName"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["BaseCatalogName"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["BaseColumnName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["BaseSchemaName"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["BaseTableName"]);
                     Assert.Equal(typeof(Int64), schema.Rows[3]["DataType"]);
                     Assert.Equal("INTEGER", schema.Rows[3]["DataTypeName"]);

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -922,6 +922,105 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+        [Fact]
+        public void GetSchemaTable_works()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+                connection.ExecuteNonQuery(
+                    "CREATE TABLE Person (ID INTEGER PRIMARY KEY, FirstName TEXT, LastName TEXT NOT NULL, Code INT UNIQUE);");
+                connection.ExecuteNonQuery("INSERT INTO Person VALUES(101, 'John', 'Dee', 123);");
+                connection.ExecuteNonQuery("INSERT INTO Person VALUES(105, 'Jane', 'Doe', 456);");
+
+                using (var reader = connection.ExecuteReader("SELECT LastName, ID, Code, ID+1 AS IncID FROM Person;"))
+                {
+                    var schema = reader.GetSchemaTable();
+                    Assert.True(schema.Columns.Contains("ColumnName"));
+                    Assert.True(schema.Columns.Contains("ColumnOrdinal"));
+                    Assert.True(schema.Columns.Contains("IsUnique"));
+                    Assert.True(schema.Columns.Contains("IsKey"));
+                    Assert.True(schema.Columns.Contains("BaseServerName"));
+                    Assert.True(schema.Columns.Contains("BaseCatalogName"));
+                    Assert.True(schema.Columns.Contains("BaseColumnName"));
+                    Assert.True(schema.Columns.Contains("BaseTableName"));
+                    Assert.True(schema.Columns.Contains("DataType"));
+                    Assert.True(schema.Columns.Contains("DataTypeName"));
+                    Assert.True(schema.Columns.Contains("AllowDBNull"));
+                    Assert.True(schema.Columns.Contains("IsAliased"));
+                    Assert.True(schema.Columns.Contains("IsExpression"));
+                    Assert.True(schema.Columns.Contains("IsAutoIncrement"));
+                    Assert.True(schema.Columns.Contains("IsLong"));
+
+                    Assert.Equal(4, schema.Rows.Count);
+
+                    Assert.Equal("LastName", schema.Rows[0]["ColumnName"]);
+                    Assert.Equal(0, schema.Rows[0]["ColumnOrdinal"]);
+                    Assert.False((bool)schema.Rows[0]["IsUnique"]);
+                    Assert.False((bool)schema.Rows[0]["IsKey"]);
+                    Assert.Equal("", schema.Rows[0]["BaseServerName"]);
+                    Assert.Equal("main", schema.Rows[0]["BaseCatalogName"]);
+                    Assert.Equal("LastName", schema.Rows[0]["BaseColumnName"]);
+                    Assert.Equal("Person", schema.Rows[0]["BaseTableName"]);
+                    Assert.Equal(typeof(String), schema.Rows[0]["DataType"]);
+                    Assert.Equal("TEXT", schema.Rows[0]["DataTypeName"]);
+                    Assert.False((bool)schema.Rows[0]["AllowDBNull"]);
+                    Assert.False((bool)schema.Rows[0]["IsAliased"]);
+                    Assert.False((bool)schema.Rows[0]["IsExpression"]);
+                    Assert.False((bool)schema.Rows[0]["IsAutoIncrement"]);
+                    Assert.False((bool)schema.Rows[0]["IsLong"]);
+
+                    Assert.Equal("ID", schema.Rows[1]["ColumnName"]);
+                    Assert.Equal(1, schema.Rows[1]["ColumnOrdinal"]);
+                    Assert.False((bool)schema.Rows[1]["IsUnique"]);
+                    Assert.True((bool)schema.Rows[1]["IsKey"]);
+                    Assert.Equal("", schema.Rows[1]["BaseServerName"]);
+                    Assert.Equal("main", schema.Rows[1]["BaseCatalogName"]);
+                    Assert.Equal("ID", schema.Rows[1]["BaseColumnName"]);
+                    Assert.Equal("Person", schema.Rows[1]["BaseTableName"]);
+                    Assert.Equal(typeof(Int64), schema.Rows[1]["DataType"]);
+                    Assert.Equal("INTEGER", schema.Rows[1]["DataTypeName"]);
+                    Assert.True((bool)schema.Rows[1]["AllowDBNull"]);
+                    Assert.False((bool)schema.Rows[1]["IsAliased"]);
+                    Assert.False((bool)schema.Rows[1]["IsExpression"]);
+                    Assert.False((bool)schema.Rows[1]["IsAutoIncrement"]);
+                    Assert.True((bool)schema.Rows[1]["IsLong"]);
+
+                    Assert.Equal("Code", schema.Rows[2]["ColumnName"]);
+                    Assert.Equal(2, schema.Rows[2]["ColumnOrdinal"]);
+                    Assert.True((bool)schema.Rows[2]["IsUnique"]);
+                    Assert.False((bool)schema.Rows[2]["IsKey"]);
+                    Assert.Equal("", schema.Rows[2]["BaseServerName"]);
+                    Assert.Equal("main", schema.Rows[2]["BaseCatalogName"]);
+                    Assert.Equal("Code", schema.Rows[2]["BaseColumnName"]);
+                    Assert.Equal("Person", schema.Rows[2]["BaseTableName"]);
+                    Assert.Equal(typeof(Int64), schema.Rows[2]["DataType"]);
+                    Assert.Equal("INT", schema.Rows[2]["DataTypeName"]);
+                    Assert.True((bool)schema.Rows[2]["AllowDBNull"]);
+                    Assert.False((bool)schema.Rows[2]["IsAliased"]);
+                    Assert.False((bool)schema.Rows[2]["IsExpression"]);
+                    Assert.False((bool)schema.Rows[2]["IsAutoIncrement"]);
+                    Assert.True((bool)schema.Rows[2]["IsLong"]);
+
+                    Assert.Equal("IncID", schema.Rows[3]["ColumnName"]);
+                    Assert.Equal(3, schema.Rows[3]["ColumnOrdinal"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["IsUnique"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["IsKey"]);
+                    Assert.Equal("", schema.Rows[3]["BaseServerName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["BaseCatalogName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["BaseColumnName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["BaseTableName"]);
+                    Assert.Equal(typeof(Int64), schema.Rows[3]["DataType"]);
+                    Assert.Equal("INTEGER", schema.Rows[3]["DataTypeName"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["AllowDBNull"]);
+                    Assert.True((bool)schema.Rows[3]["IsAliased"]);
+                    Assert.True((bool)schema.Rows[3]["IsExpression"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["IsAutoIncrement"]);
+                    Assert.True((bool)schema.Rows[3]["IsLong"]);
+                }
+            }
+        }
+
         private static void GetX_works<T>(string sql, Func<DbDataReader, T> action, T expected)
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -968,7 +968,7 @@ namespace Microsoft.Data.Sqlite
                     Assert.False((bool)schema.Rows[0]["IsAliased"]);
                     Assert.False((bool)schema.Rows[0]["IsExpression"]);
                     Assert.False((bool)schema.Rows[0]["IsAutoIncrement"]);
-                    Assert.False((bool)schema.Rows[0]["IsLong"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[0]["IsLong"]);
 
                     Assert.Equal("ID", schema.Rows[1]["ColumnName"]);
                     Assert.Equal(1, schema.Rows[1]["ColumnOrdinal"]);
@@ -984,7 +984,7 @@ namespace Microsoft.Data.Sqlite
                     Assert.False((bool)schema.Rows[1]["IsAliased"]);
                     Assert.False((bool)schema.Rows[1]["IsExpression"]);
                     Assert.False((bool)schema.Rows[1]["IsAutoIncrement"]);
-                    Assert.True((bool)schema.Rows[1]["IsLong"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[1]["IsLong"]);
 
                     Assert.Equal("Code", schema.Rows[2]["ColumnName"]);
                     Assert.Equal(2, schema.Rows[2]["ColumnOrdinal"]);
@@ -1000,7 +1000,7 @@ namespace Microsoft.Data.Sqlite
                     Assert.False((bool)schema.Rows[2]["IsAliased"]);
                     Assert.False((bool)schema.Rows[2]["IsExpression"]);
                     Assert.False((bool)schema.Rows[2]["IsAutoIncrement"]);
-                    Assert.True((bool)schema.Rows[2]["IsLong"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[2]["IsLong"]);
 
                     Assert.Equal("IncID", schema.Rows[3]["ColumnName"]);
                     Assert.Equal(3, schema.Rows[3]["ColumnOrdinal"]);
@@ -1016,7 +1016,7 @@ namespace Microsoft.Data.Sqlite
                     Assert.True((bool)schema.Rows[3]["IsAliased"]);
                     Assert.True((bool)schema.Rows[3]["IsExpression"]);
                     Assert.Equal(DBNull.Value, schema.Rows[3]["IsAutoIncrement"]);
-                    Assert.True((bool)schema.Rows[3]["IsLong"]);
+                    Assert.Equal(DBNull.Value, schema.Rows[3]["IsLong"]);
                 }
             }
         }


### PR DESCRIPTION
Add initial implementation of DbDataReader.GetSchemaTable.

This is based on the table in #253. The null entries are commented out at the moment. For the sequence of columns I used the same order as in SqlDataReader (https://referencesource.microsoft.com/#System.Data/System/Data/SqlClient/SqlDataReader.cs,451).

sqlite3_table_column_metadata is not supported by SQLitePCL.raw yet, so that IsKey, AllowDBNull and IsAutoIncrement are not implemented.

Addresses #253