### PR TITLE
Allow reading TimeSpan from INTEGER/REAL

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -307,6 +307,14 @@ namespace Microsoft.Data.Sqlite
             => _record.GetDateTimeOffset(ordinal);
 
         /// <summary>
+        /// Gets the value of the specified column as a <see cref="TimeSpan" />.
+        /// </summary>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <returns>The value of the column.</returns>
+        public virtual TimeSpan GetTimeSpan(int ordinal)
+            => _record.GetTimeSpan(ordinal);
+
+        /// <summary>
         /// Gets the value of the specified column as a <see cref="decimal" />.
         /// </summary>
         /// <param name="ordinal">The zero-based column ordinal.</param>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueReader.cs
@@ -84,8 +84,18 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
-        protected virtual TimeSpan GetTimeSpan(int ordinal)
-            => TimeSpan.Parse(GetString(ordinal));
+        public virtual TimeSpan GetTimeSpan(int ordinal)
+        {
+            var sqliteType = GetSqliteType(ordinal);
+            switch (sqliteType)
+            {
+                case raw.SQLITE_FLOAT:
+                case raw.SQLITE_INTEGER:
+                    return TimeSpan.FromDays(GetDouble(ordinal));
+                default:
+                    return TimeSpan.Parse(GetString(ordinal));
+            }
+        }
 
         public virtual short GetInt16(int ordinal)
             => (short)GetInt64(ordinal);

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -146,6 +146,27 @@ namespace Microsoft.Data.Sqlite
                 new DateTimeOffset(new DateTime(2013, 10, 7, 12, 0, 0)));
 
         [Fact]
+        public void GetTimeSpan_works_with_text()
+            => GetX_works(
+                "SELECT '12:06:29';",
+                r => ((SqliteDataReader)r).GetTimeSpan(0),
+                new TimeSpan(12, 06, 29));
+
+        [Fact]
+        public void GetTimeSpan_works_with_real()
+            => GetX_works(
+                "SELECT julianday('2013-10-12 09:25:22.120') - julianday('2013-10-07 08:23:19');",
+                r => ((SqliteDataReader)r).GetTimeSpan(0),
+                new TimeSpan(5, 1, 2, 3, 120));
+
+        [Fact]
+        public void GetTimeSpan_works_with_integer()
+            => GetX_works(
+                "SELECT CAST(julianday('2017-08-31') - julianday('1776-07-04') AS INTEGER);",
+                r => ((SqliteDataReader)r).GetTimeSpan(0),
+                new TimeSpan(88081, 0, 0, 0));
+
+        [Fact]
         public void GetDateTimeOffset_throws_when_null()
             => GetX_throws_when_null(r => ((SqliteDataReader)r).GetDateTimeOffset(0));
 


### PR DESCRIPTION
Adds GetTimeSpan to SqliteDataReader and implements conversion from REAL to TimeSpan (assumed is that the value represents the fractional number of days (e.g. as result of a subtraction of two Julian date values)).

Addresses #411 
