### PR TITLE
Implements SqliteParamter: Honor SqliteType

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Sqlite
         private string _parameterName = string.Empty;
         private object _value;
         private int? _size;
+        private SqliteType? _sqliteType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqliteParameter" /> class.
@@ -96,7 +97,11 @@ namespace Microsoft.Data.Sqlite
         /// <value>The SQLite type of the parameter.</value>
         /// <remarks>Due to SQLite's dynamic type system, parameter values are not converted.</remarks>
         /// <seealso href="http://sqlite.org/datatype3.html">Datatypes In SQLite Version 3</seealso>
-        public virtual SqliteType SqliteType { get; set; } = SqliteType.Text;
+        public virtual SqliteType SqliteType
+        {
+            get => _sqliteType ?? SqliteValueBinder.GetSqliteType(_value);
+            set => _sqliteType = value;
+        }
 
         /// <summary>
         /// Gets or sets the direction of the parameter. Only <see cref="ParameterDirection.Input" /> is supported.
@@ -212,7 +217,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Resources.RequiresSet(nameof(Value)));
             }
 
-            new SqliteParameterBinder(stmt, index, _value, _size).Bind();
+            new SqliteParameterBinder(stmt, index, _value, _size, _sqliteType).Bind();
 
             return true;
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterBinder.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Data.Sqlite
         private readonly int _index;
         private readonly int? _size;
 
-        public SqliteParameterBinder(sqlite3_stmt stmt, int index, object value, int? size)
-            : base(value)
+        public SqliteParameterBinder(sqlite3_stmt stmt, int index, object value, int? size, SqliteType? sqliteType)
+            : base(value, sqliteType)
         {
             _stmt = stmt;
             _index = index;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteValueBinder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Data.Sqlite.Properties;
 
@@ -11,10 +12,17 @@ namespace Microsoft.Data.Sqlite
     internal abstract class SqliteValueBinder
     {
         private readonly object _value;
+        private readonly SqliteType? _sqliteType;
 
         protected SqliteValueBinder(object value)
+            : this(value, null)
+        {
+        }
+
+        protected SqliteValueBinder(object value, SqliteType? sqliteType)
         {
             _value = value;
+            _sqliteType = sqliteType;
         }
 
         protected abstract void BindInt64(long value);
@@ -64,18 +72,45 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(char))
             {
-                var value = (long)(char)_value;
-                BindInt64(value);
+                var chr = (char)_value;
+                if (_sqliteType == SqliteType.Text)
+                {
+                    var value = new string(chr, 1);
+                    BindText(value);
+                }
+                else
+                {
+                    var value = (long)chr;
+                    BindInt64(value);
+                }
             }
             else if (type == typeof(DateTime))
             {
-                var value = ((DateTime)_value).ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF");
-                BindText(value);
+                var dateTime = (DateTime)_value;
+                if (_sqliteType == SqliteType.Real)
+                {
+                    var value = ToJulianDate(dateTime);
+                    BindDouble(value);
+                }
+                else
+                {
+                    var value = dateTime.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF");
+                    BindText(value);
+                }
             }
             else if (type == typeof(DateTimeOffset))
             {
-                var value = ((DateTimeOffset)_value).ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz");
-                BindText(value);
+                var dateTime = (DateTimeOffset)_value;
+                if (_sqliteType == SqliteType.Real)
+                {
+                    var value = ToJulianDate(dateTime.DateTime);
+                    BindDouble(value);
+                }
+                else
+                {
+                    var value = dateTime.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz");
+                    BindText(value);
+                }
             }
             else if (type == typeof(DBNull))
             {
@@ -98,8 +133,17 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(Guid))
             {
-                var value = ((Guid)_value).ToByteArray();
-                BindBlob(value);
+                var guid = (Guid)_value;
+                if (_sqliteType == SqliteType.Text)
+                {
+                    var value = guid.ToString().ToUpper();
+                    BindText(value);
+                }
+                else
+                {
+                    var value = guid.ToByteArray();
+                    BindBlob(value);
+                }
             }
             else if (type == typeof(int))
             {
@@ -128,8 +172,17 @@ namespace Microsoft.Data.Sqlite
             }
             else if (type == typeof(TimeSpan))
             {
-                var value = ((TimeSpan)_value).ToString("c");
-                BindText(value);
+                var timeSpan = (TimeSpan)_value;
+                if (_sqliteType == SqliteType.Real)
+                {
+                    var value = timeSpan.TotalDays;
+                    BindDouble(value);
+                }
+                else
+                {
+                    var value = timeSpan.ToString("c");
+                    BindText(value);
+                }
             }
             else if (type == typeof(uint))
             {
@@ -150,6 +203,73 @@ namespace Microsoft.Data.Sqlite
             {
                 throw new InvalidOperationException(Resources.UnknownDataType(type));
             }
+        }
+
+        private static readonly Dictionary<Type, SqliteType> _sqliteTypeMapping =
+            new Dictionary<Type, SqliteType>()
+            {
+                {typeof(bool), SqliteType.Integer},
+                {typeof(byte),SqliteType.Integer},
+                {typeof(byte[]), SqliteType.Blob},
+                {typeof(char),SqliteType.Integer},
+                {typeof(DateTime), SqliteType.Text},
+                {typeof(DateTimeOffset), SqliteType.Text},
+                {typeof(DBNull), SqliteType.Text},
+                {typeof(decimal),SqliteType.Text},
+                {typeof(double), SqliteType.Real},
+                {typeof(float), SqliteType.Real},
+                {typeof(Guid), SqliteType.Blob},
+                {typeof(int), SqliteType.Integer},
+                {typeof(long), SqliteType.Integer},
+                {typeof(sbyte),SqliteType.Integer},
+                {typeof(short), SqliteType.Integer},
+                {typeof(string), SqliteType.Integer},
+                {typeof(TimeSpan), SqliteType.Text},
+                {typeof(uint), SqliteType.Integer},
+                {typeof(ulong), SqliteType.Integer},
+                {typeof(ushort), SqliteType.Integer},
+            };
+
+        internal static SqliteType GetSqliteType(object value)
+        {
+            if (value == null)
+            {
+                return SqliteType.Text;
+            }
+
+            var type = value.GetType().UnwrapNullableType().UnwrapEnumType();
+            if (_sqliteTypeMapping.TryGetValue(type, out var sqliteType))
+            {
+                return sqliteType;
+            }
+            else
+            {
+                throw new InvalidOperationException(Resources.UnknownDataType(type));
+            }
+        }
+
+        private static double ToJulianDate(DateTime dateTime)
+        {
+            // computeJD
+            var Y = dateTime.Year;
+            var M = dateTime.Month;
+            var D = dateTime.Day;
+
+            if (M <= 2)
+            {
+                Y--;
+                M += 12;
+            }
+
+            var A = Y / 100;
+            var B = 2 - A + (A / 4);
+            var X1 = 36525 * (Y + 4716) / 100;
+            var X2 = 306001 * (M + 1) / 10000;
+            var iJD = (long)((X1 + X2 + D + B - 1524.5) * 86400000);
+
+            iJD += dateTime.Hour * 3600000 + dateTime.Minute * 60000 + (long)((dateTime.Second + dateTime.Millisecond / 1000.0) * 1000);
+
+            return iJD / 86400000.0;
         }
     }
 }


### PR DESCRIPTION
In order to leave the default behaviour (for char and Guid) unchanged I added SqliteType.Undefined and used it as new default value for SqliteType (was Text before).

Addresses #418 
