### PR TITLE
Improve SqliteDataReader.GetSchemaTable() DataType

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -540,6 +540,19 @@ namespace Microsoft.Data.Sqlite
 
                         var cnt = (long)command.ExecuteScalar();
                         schemaRow[IsUnique] = cnt != 0;
+
+                        command.Parameters.Clear();
+                        var columnType = "typeof(\"" + columnName.Replace("\"", "\"\"") + "\")";
+                        command.CommandText = new StringBuilder()
+                            .AppendLine($"SELECT {columnType}")
+                            .AppendLine($"FROM \"{tableName}\"")
+                            .AppendLine($"WHERE {columnType} != 'null'")
+                            .AppendLine($"GROUP BY {columnType}")
+                            .AppendLine("ORDER BY count() DESC")
+                            .AppendLine("LIMIT 1;").ToString();
+
+                        var type = (string)command.ExecuteScalar();
+                        schemaRow[DataType] = SqliteDataRecord.GetFieldType(type);
                     }
 
                     if (!string.IsNullOrEmpty(databaseName))

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -144,6 +144,31 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
+        public static Type GetFieldType(string type)
+        {
+            switch (type)
+            {
+                case "integer":
+                    return typeof(long);
+
+                case "real":
+                    return typeof(double);
+
+                case "text":
+                    return typeof(string);
+
+                case "blob":
+                    return typeof(byte[]);
+
+                case null:
+                    return typeof(int);
+
+                default:
+                    Debug.Assert(false, "Unexpected column type: " + type);
+                    return typeof(int);
+            }
+        }
+
         public virtual long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
             => throw new NotSupportedException();
 


### PR DESCRIPTION
Note that column and table names cannot be bound using parameters (I enclosed them in " to make SQL injection attacks less likely).

Addresses #436 
