### PR TITLE
Handle extended result codes

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -352,7 +352,8 @@ namespace Microsoft.Data.Sqlite
 
                     var timer = Stopwatch.StartNew();
                     while (raw.SQLITE_LOCKED == (rc = raw.sqlite3_step(stmt))
-                           || rc == raw.SQLITE_BUSY)
+                           || rc == raw.SQLITE_BUSY
+                           || rc == raw.SQLITE_LOCKED_SHAREDCACHE)
                     {
                         if (timer.ElapsedMilliseconds >= CommandTimeout * 1000)
                         {

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -720,8 +720,10 @@ namespace Microsoft.Data.Sqlite
             }
         }
 
-        [Fact]
-        public Task ExecuteReader_retries_when_locked()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task ExecuteReader_retries_when_locked(bool extendedErrorCode)
         {
             const string connectionString = "Data Source=locked;Mode=Memory;Cache=Shared";
 
@@ -734,6 +736,10 @@ namespace Microsoft.Data.Sqlite
                             using (var connection = new SqliteConnection(connectionString))
                             {
                                 connection.Open();
+                                if (extendedErrorCode)
+                                {
+                                    raw.sqlite3_extended_result_codes(connection.Handle, 1);
+                                }
 
                                 connection.ExecuteNonQuery(
                                     "CREATE TABLE Data (Value); INSERT INTO Data VALUES (0);");
@@ -752,6 +758,10 @@ namespace Microsoft.Data.Sqlite
                             using (var connection = new SqliteConnection(connectionString))
                             {
                                 connection.Open();
+                                if (extendedErrorCode)
+                                {
+                                    raw.sqlite3_extended_result_codes(connection.Handle, 1);
+                                }
 
                                 selectedSignal.WaitOne();
 


### PR DESCRIPTION
I ran the tests once with `raw.sqlite3_extended_result_codes(_db, 1);` added to `Connection.Open` and only the test `ExecuteReader_retries_when_locked` failed.

Addresses #459