### PR TITLE
Fix AddRange(Array values)

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
@@ -132,7 +132,13 @@ namespace Microsoft.Data.Sqlite
         ///     An array of parameters to add. They must be <see cref="SqliteParameter" /> objects.
         /// </param>
         public override void AddRange(Array values)
-            => Add(values.Cast<SqliteParameter>());
+        {
+            int valueCount = values.Length;
+            for (int i = 0; i < valueCount; i++)
+            {
+                Add((SqliteParameter)values.GetValue(i));
+            }
+        }
 
         /// <summary>
         ///     Adds multiple parameters to the collection.

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameterCollection.cs
@@ -132,13 +132,7 @@ namespace Microsoft.Data.Sqlite
         ///     An array of parameters to add. They must be <see cref="SqliteParameter" /> objects.
         /// </param>
         public override void AddRange(Array values)
-        {
-            int valueCount = values.Length;
-            for (int i = 0; i < valueCount; i++)
-            {
-                Add((SqliteParameter)values.GetValue(i));
-            }
-        }
+            => AddRange(values.Cast<SqliteParameter>());
 
         /// <summary>
         ///     Adds multiple parameters to the collection.

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -392,9 +392,9 @@ namespace Microsoft.Data.Sqlite
             }
         }
         
-		[Fact]
-		public void Add_range_of_parameters_using_DbCommand_base_class()
-		{
+        [Fact]
+        public void Add_range_of_parameters_using_DbCommand_base_class()
+        {
             using (var connection = new SqliteConnection("Data Source=:memory:"))
             {
                 var command = connection.CreateCommand() as DbCommand;
@@ -413,12 +413,12 @@ namespace Microsoft.Data.Sqlite
 
                 using (var reader = command.ExecuteReader())
                 {
-					Assert.True(reader.Read());
-					Assert.Equal(parameterValue1.Value, reader.GetString(0));
-					Assert.Equal(parameterValue2.Value, reader.GetString(1));
+                    Assert.True(reader.Read());
+                    Assert.Equal(parameterValue1.Value, reader.GetString(0));
+                    Assert.Equal(parameterValue2.Value, reader.GetString(1));
                 }
-            }		
-		}        
+            }
+        }      
 
         private enum MyEnum
         {

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteParameterTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.Sqlite.Properties;
 using Xunit;
 
@@ -390,6 +391,34 @@ namespace Microsoft.Data.Sqlite
                 }
             }
         }
+        
+		[Fact]
+		public void Add_range_of_parameters_using_DbCommand_base_class()
+		{
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                var command = connection.CreateCommand() as DbCommand;
+                command.CommandText = "SELECT @Value1, @Value2;";
+
+                var parameterValue1 = new SqliteParameter("@Value1", SqliteType.Text);
+                parameterValue1.Value = "ABCDE";
+
+                var parameterValue2 = new SqliteParameter("@Value2", SqliteType.Text);
+                parameterValue2.Value = "FGHIJ";
+
+                var parameters = new[] { parameterValue1, parameterValue2 };
+
+                command.Parameters.AddRange(parameters);
+                connection.Open();
+
+                using (var reader = command.ExecuteReader())
+                {
+					Assert.True(reader.Read());
+					Assert.Equal(parameterValue1.Value, reader.GetString(0));
+					Assert.Equal(parameterValue2.Value, reader.GetString(1));
+                }
+            }		
+		}        
 
         private enum MyEnum
         {


### PR DESCRIPTION
Using the `AddRange(Array values)` method causes a exception because the result of linq `Cast<SqliteParameter>()` returns a `IEnumerable<T>` which cannot be casted to a single `SqliteParameter`.

The exception thrown: Unable to cast object of type `'<CastIterator>d__34`1[Microsoft.Data.Sqlite.SqliteParameter]' to type 'Microsoft.Data.Sqlite.SqliteParameter'.`

The method `AddRange `comes into place when working primarily with the base class `DbParameterCollection `which does not have a method accepting `IEnumerable<SqliteParameter>`