### PR TITLE
Simple overflow checking on GetBytes and GetChars

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -175,15 +175,21 @@ namespace Microsoft.Data.Sqlite
         public virtual long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
         {
             var blob = GetCachedBlob(ordinal);
-            Array.Copy(blob, dataOffset, buffer, bufferOffset, length);
-            return length;
+
+            long bytesToRead = (long)blob.Length - dataOffset;
+            bytesToRead = System.Math.Min(bytesToRead, length);
+            Array.Copy(blob, dataOffset, buffer, bufferOffset, bytesToRead);
+            return bytesToRead;
         }
 
         public virtual long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
         {
             var text = GetString(ordinal);
-            text.CopyTo((int)dataOffset, buffer, bufferOffset, length);
-            return length;
+
+            int charsToRead = text.Length - (int)dataOffset;
+            charsToRead = System.Math.Min(charsToRead, length);
+            text.CopyTo((int)dataOffset, buffer, bufferOffset, charsToRead);
+            return charsToRead;
         }
 
         public virtual Stream GetStream(int ordinal)


### PR DESCRIPTION
- With the methods that return the number of bytes that are read, it should be expected that they should safeguard against reading over the buffer length especially since the user might not know the length beforehand. 
- Before this patch, if you stuck in a length that was larger than the rest of the buffer size, the `Array.Copy` would throw an argument exception. Now, after this patch it behaves like `Stream.Read`.

There didn't seem to be an bug# associated with this. I found it when integrating the latest nightly into my app.