### PR TITLE
Remove an overmodest comment in the API docs

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Data.Sqlite
             => CreateParameter();
 
         /// <summary>
-        ///     Creates a prepared version of the command on the database. This has no effect.
+        ///     Creates a prepared version of the command on the database.
         /// </summary>
         public override void Prepare()
         {


### PR DESCRIPTION
Prepared statements are a thing since 6eaf137519e3f421551b53399abe386e65d0f8ce