### PR TITLE
Fix and Modify some codes to make it better and more strictly

### DIFF
--- a/samples/BulkInsertSample/Program.cs
+++ b/samples/BulkInsertSample/Program.cs
@@ -42,7 +42,7 @@ namespace BulkInsertSample
                 insertCommand.Parameters.Add(valueParameter);
 
                 // No need to call Prepare() since it's done lazily during the first execution.
-                //insertCommand.Prepare();
+                // insertCommand.Prepare();
 
                 var random = new Random();
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Resources.CallRequiresOpenConnection(nameof(Prepare)));
             }
 
-            if (string.IsNullOrEmpty(_commandText))
+            if (string.IsNullOrWhiteSpace(_commandText))
             {
                 throw new InvalidOperationException(Resources.CallRequiresSetCommandText(nameof(Prepare)));
             }
@@ -298,7 +298,7 @@ namespace Microsoft.Data.Sqlite
                 throw new InvalidOperationException(Resources.CallRequiresOpenConnection(nameof(ExecuteReader)));
             }
 
-            if (string.IsNullOrEmpty(_commandText))
+            if (string.IsNullOrWhiteSpace(_commandText))
             {
                 throw new InvalidOperationException(Resources.CallRequiresSetCommandText(nameof(ExecuteReader)));
             }
@@ -479,15 +479,15 @@ namespace Microsoft.Data.Sqlite
             {
                 throw new InvalidOperationException(Resources.CallRequiresOpenConnection(nameof(ExecuteNonQuery)));
             }
-            if (_commandText == null)
+            if (string.IsNullOrWhiteSpace(_commandText))
             {
                 throw new InvalidOperationException(Resources.CallRequiresSetCommandText(nameof(ExecuteNonQuery)));
             }
 
-            var reader = ExecuteReader();
-            reader.Dispose();
-
-            return reader.RecordsAffected;
+            using (var reader = ExecuteReader())
+            {
+                return reader.RecordsAffected;
+            }
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace Microsoft.Data.Sqlite
             {
                 throw new InvalidOperationException(Resources.CallRequiresOpenConnection(nameof(ExecuteScalar)));
             }
-            if (_commandText == null)
+            if (string.IsNullOrWhiteSpace(_commandText))
             {
                 throw new InvalidOperationException(Resources.CallRequiresSetCommandText(nameof(ExecuteScalar)));
             }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Data.Sqlite
             {
                 return;
             }
-            if (ConnectionString == null)
+            if (string.IsNullOrWhiteSpace(ConnectionString))
             {
                 throw new InvalidOperationException(Resources.OpenRequiresSetConnectionString);
             }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteParameter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="value">The value of the parameter. Can be null.</param>
         public SqliteParameter(string name, object value)
         {
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Sqlite
         /// <param name="type">The type of the parameter.</param>
         public SqliteParameter(string name, SqliteType type)
         {
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Sqlite
             get => _parameterName;
             set
             {
-                if (string.IsNullOrEmpty(value))
+                if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new ArgumentNullException(nameof(value));
                 }


### PR DESCRIPTION
1) Use IsNullOrWhiteSpace instead of IsNullOrEmpty for SqliteParameter's
name and SqlCommand's _commandText, because we don't wanna see names full of white spaces or invisible symbols (They are meaningless at all).

2) Use `using.....` instead of exclipitly calling `Dispose()`.

3) Add a space in the comment for `BulkInsertSample`.