### PR TITLE
Check for null in buffer[] and return appropriate value

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -178,7 +178,8 @@ namespace Microsoft.Data.Sqlite
 
             long bytesToRead = (long)blob.Length - dataOffset;
             bytesToRead = System.Math.Min(bytesToRead, length);
-            Array.Copy(blob, dataOffset, buffer, bufferOffset, bytesToRead);
+            if (buffer != null)
+                Array.Copy(blob, dataOffset, buffer, bufferOffset, bytesToRead);
             return bytesToRead;
         }
 

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -177,9 +177,11 @@ namespace Microsoft.Data.Sqlite
             var blob = GetCachedBlob(ordinal);
 
             long bytesToRead = (long)blob.Length - dataOffset;
-            bytesToRead = System.Math.Min(bytesToRead, length);
             if (buffer != null)
+            {
+                bytesToRead = System.Math.Min(bytesToRead, length);
                 Array.Copy(blob, dataOffset, buffer, bufferOffset, bytesToRead);
+            }
             return bytesToRead;
         }
 

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -81,6 +81,27 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void GetBytes_NullBuffer()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                using (var reader = connection.ExecuteReader("SELECT x'427E5743';"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    byte[] buffer = null;
+                    long bytesRead = reader.GetBytes(0, 1, buffer, 0, 3);
+
+                    // Expecting to return the length of the field in bytes,
+                    // which can be simply be blob length minus the offset. 
+                    Assert.Equal(3, bytesRead);
+                }
+            }
+        }
+        [Fact]
         public void GetBytes_works_with_overflow()
         {
             using (var connection = new SqliteConnection("Data Source=:memory:"))


### PR DESCRIPTION
OK, this looks better.

Have GetBytes() handle buffer null value appropriately without the need for code external to this API to do so.

I'd like to get this fix into 2.2.0 release.  Thank you.